### PR TITLE
The Epstein Civil violence model was modified to include sliders and …

### DIFF
--- a/examples/EpsteinCivilViolence/Readme.md
+++ b/examples/EpsteinCivilViolence/Readme.md
@@ -1,33 +1,40 @@
 # Epstein Civil Violence Model
+##### Adapted by Daniel Muysken, Zazo Meijs, Cornelis Boon, Tamika van 't Hoff and Julia Anten
 
 ## Summary
 
-This model is based on Joshua Epstein's simulation of how civil unreast grows and is suppressed. Citizen agents wander the grid randomly, and are endowed with individual risk aversion and hardship levels; there is also a universal regime legitimacy value. There are also Cop agents, who work on behalf of the regime. Cops arrest Citizens who are actively rebelling; Citiens decide whether to rebel based on their hardship and the regime legitimacy, and their perceived probability of arrest. 
+This model is based on Joshua Epstein's simulation of how civil unrest grows and is suppressed. Citizen agents wander the grid randomly, and are endowed with individual risk aversion and hardship levels; there is also a universal regime legitimacy value. There are also Cop agents, who work on behalf of the regime. Cops arrest Citizens who are actively rebelling; Citicens decide whether to rebel based on their hardship and the regime legitimacy, and their perceived probability of arrest. 
 
 The model generates mass uprising as self-reinforcing proceses: if enough agents are rebelling, the probability of any individual agent being arrested is reduced, making more agents more likely to join the uprising. However, the more rebelling Citizens the Cops arrest, the less likely additional agents become to join.
 
+## Improvements
+- Vision parameter implemented.
+- Added sliders to make the model easier to use. 
+
 ## How to Run
 
-To run the model interactively, run ``EpsteinCivilViolenceServer.py`` in this directory. e.g.
+To run the model interactively, run ``run.py`` in this directory. e.g.
 
 ```
-    $ python EpsteinCivilViolenceServer.py
+    $ python run.py
 ``` 
 
 Then open your browser to [http://127.0.0.1:8888/](http://127.0.0.1:8888/) and press Reset, then Run. 
 
 ## Files
 
-* ``EpsteinCivilViolence.py``: Core model and agent code.
-* ``EpsteinCivilViolenceServer.py``: Sets up the interactive visualization.
+* ``Agent.py``: Agent code.
+* ``Model.py``: Core model code.
+* ``Server.py``: Sets up the interactive visualisation.
 * ``Epstein Civil Violence.ipynb``: Jupyter notebook conducting some preliminary analysis of the model.
 
 ## Further Reading
 
-This model is based adapted from:
+This model is adapted from:
 
 [Epstein, J. “Modeling civil violence: An agent-based computational approach”, Proceedings of the National Academy of Sciences, Vol. 99, Suppl. 3, May 14, 2002](http://www.pnas.org/content/99/suppl.3/7243.short)
 
 A similar model is also included with NetLogo:
 
-Wilensky, U. (2004). NetLogo Rebellion model. http://ccl.northwestern.edu/netlogo/models/Rebellion. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+Wilensky, U. (2004). NetLogo Rebellion model. http://ccl.northwestern.edu/netlogo/models/Rebellion. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL. <br>
+Although, in this model, it is possible for agents to occupy the same space.

--- a/examples/EpsteinCivilViolence/civil_violence/agent.py
+++ b/examples/EpsteinCivilViolence/civil_violence/agent.py
@@ -86,7 +86,7 @@ class Citizen(Agent):
         Look around and see who my neighbors are
         """
         self.neighborhood = self.model.grid.get_neighborhood(self.pos,
-                                                        moore=False, radius=1)
+                                                        moore=self.model.moore, radius=self.vision)
         self.neighbors = self.model.grid.get_cell_list_contents(self.neighborhood)
         self.empty_neighbors = [c for c in self.neighborhood if
                                 self.model.grid.is_cell_empty(c)]
@@ -161,7 +161,7 @@ class Cop(Agent):
         Look around and see who my neighbors are.
         """
         self.neighborhood = self.model.grid.get_neighborhood(self.pos,
-                                                        moore=False, radius=1)
+                                                        moore=self.model.moore, radius=self.vision)
         self.neighbors = self.model.grid.get_cell_list_contents(self.neighborhood)
         self.empty_neighbors = [c for c in self.neighborhood if
                                 self.model.grid.is_cell_empty(c)]

--- a/examples/EpsteinCivilViolence/civil_violence/model.py
+++ b/examples/EpsteinCivilViolence/civil_violence/model.py
@@ -18,13 +18,13 @@ class CivilViolenceModel(Model):
         width: grid width
         citizen_density: approximate % of cells occupied by citizens.
         cop_density: approximate % of calles occupied by cops.
-        citizen_vision: number of cells in each direction (N, S, E and W) that
-            citizen can inspect
-        cop_vision: number of cells in each direction (N, S, E and W) that cop
-            can inspect
+        citizen_vision: number of cells in each direction citizen can inspect, 
+            either von Neumann or Moore neighborhood.
+        cop_vision: number of cells in each direction that cop can inspect,
+            either von Neumann or Moore neighborhood.
         legitimacy:  (L) citizens' perception of regime legitimacy, equal
             across all citizens
-        max_jail_term: (J_max)
+        max_jail_term: (J_max), actual jail terms are intergers uniformly distributed from 0 to J_max
         active_threshold: if (grievance - (risk_aversion * arrest_probability))
             > threshold, citizen rebels
         arrest_prob_constant: set to ensure agents make plausible arrest
@@ -32,13 +32,12 @@ class CivilViolenceModel(Model):
         movement: binary, whether agents try to move at step end
         max_iters: model may not have a natural stopping point, so we set a
             max.
-
     """
 
     def __init__(self, height, width, citizen_density, cop_density,
                  citizen_vision, cop_vision, legitimacy,
-                 max_jail_term, active_threshold=.1, arrest_prob_constant=2.3,
-                 movement=True, max_iters=1000):
+                 max_jail_term, active_threshold = .1, arrest_prob_constant = 2.3,
+                 movement = True, max_iters = 1000, moore = "Neumann"):
         super().__init__()
         self.height = height
         self.width = width
@@ -56,6 +55,11 @@ class CivilViolenceModel(Model):
         self.iteration = 0
         self.schedule = RandomActivation(self)
         self.grid = Grid(height, width, torus=True)
+        if moore == "Moore":
+            self.moore = 1
+        else:
+            self.moore = 0
+
         model_reporters = {
             "Quiescent": lambda m: self.count_type_citizens(m, "Quiescent"),
             "Active": lambda m: self.count_type_citizens(m, "Active"),

--- a/examples/EpsteinCivilViolence/civil_violence/server.py
+++ b/examples/EpsteinCivilViolence/civil_violence/server.py
@@ -1,5 +1,9 @@
 from mesa.visualization.ModularVisualization import ModularServer
-from mesa.visualization.modules import CanvasGrid
+from mesa.visualization.modules import CanvasGrid, ChartModule, TextElement
+from mesa.visualization.UserParam import UserSettableParameter
+from mesa.visualization.TextVisualization import (
+    TextData, TextGrid, TextVisualization
+)
 
 from .model import CivilViolenceModel
 from .agent import Citizen, Cop
@@ -29,18 +33,34 @@ def citizen_cop_portrayal(agent):
 
     elif type(agent) is Cop:
         portrayal["Color"] = COP_COLOR
-        portrayal["r"] = 0.5
+        portrayal["w"] = 0.5
+        portrayal["h"] = 0.5
         portrayal["Layer"] = 1
+        portrayal["Shape"] = "rect"
     return portrayal
 
 canvas_element = CanvasGrid(citizen_cop_portrayal, 40, 40, 500, 500)
-server = ModularServer(CivilViolenceModel, [canvas_element],
+active_chart = ChartModule([{"Label": "Active", "Color": "Red"}, {"Label": "Jailed", "Color": "Black"}, {"Label": "Quiescent", "Color": "Orange"}], data_collector_name="dc")
+leg_slider = UserSettableParameter('slider', "legitimacy", 0.8, 0., 1., 0.001)
+cit_vis_slider = UserSettableParameter('slider', "Citizen vision", 3, 1, 10, 1)
+cop_vis_slider = UserSettableParameter('slider', "Cop vision", 2, 1, 10, 1)
+act_slider = UserSettableParameter('slider', "Active treshold", 0.1, 0., .5, 0.001)
+#hom_slider = UserSettableParameter('slider', "Schelling homophily", 3, 1, 9, 1)
+nb_choice = UserSettableParameter('choice', 'Neighbourhood vision setup', value='Neumann',
+                                              choices=['Neumann', 'Moore'])
+jail_slider = UserSettableParameter('slider', "Max jail time", 30, 0., 150, 1)
+server = ModularServer(CivilViolenceModel, [canvas_element, active_chart],
                        "Epstein Civil Violence",
-                       height=40,
-                       width=40,
-                       citizen_density=.7,
-                       cop_density=.074,
-                       citizen_vision=7,
-                       cop_vision=7,
-                       legitimacy=.8,
-                       max_jail_term=1000)
+                       {"height": 40,
+                       "width": 40,
+                       "citizen_density": .7,
+
+                      # Original article uses 0.04 and 0.074
+                       "cop_density": .074,
+
+                       "citizen_vision": cit_vis_slider,
+                       "cop_vision": cop_vis_slider,
+                       "legitimacy": leg_slider,
+                       "max_jail_term": jail_slider,
+                       "active_threshold": act_slider,
+                       "moore": nb_choice})


### PR DESCRIPTION
We modified the Epstein Civil Violence example to include sliders and result within the visual environment. 
Secondly we fixed a small mistake where the cop vision variable was always set to 1 in the code.
Lastly we slightly changed the portrayal of the 'cops' so they are easier to distinguish

This was done as part of the course 'Agent-Based Modeling' at the 'University of Amsterdam' (UvA).

Thank you for this basis code (and Mesa in general), for our project we shall implement some automatic variation in cops density and Legitimacy and see how this affects the outputs. But this is no longer part of the Epstein example.