### PR TITLE
Use Pathlib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+ci:
+    autoupdate_schedule: 'monthly'
+    autofix_prs: false
+
+repos:
+-   repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black-jupyter
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+    -   id: pyupgrade
+        args: [--py38-plus]
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0  # Use the ref you want to point at
+    hooks:
+    -   id: trailing-whitespace
+    -   id: check-toml
+    -   id: check-yaml

--- a/examples/caching_and_replay/run.py
+++ b/examples/caching_and_replay/run.py
@@ -18,7 +18,7 @@ def get_cache_file_status(_):
     """
     Display an informational text about caching and the status of the cache file (existing versus not existing)
     """
-    cache_file = Path('./my_cache_file_path.cache')
+    cache_file = Path("./my_cache_file_path.cache")
     return (
         f"Only activate the 'Replay cached run?' switch when a cache file already exists, otherwise it will fail. "
         f"Cache file existing: '{cache_file.exists()}'."

--- a/examples/caching_and_replay/run.py
+++ b/examples/caching_and_replay/run.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import mesa
 
@@ -18,9 +18,10 @@ def get_cache_file_status(_):
     """
     Display an informational text about caching and the status of the cache file (existing versus not existing)
     """
+    cache_file = Path('./my_cache_file_path.cache')
     return (
         f"Only activate the 'Replay cached run?' switch when a cache file already exists, otherwise it will fail. "
-        f"Cache file existing: '{os.path.exists('my_cache_file_path.cache')}'."
+        f"Cache file existing: '{cache_file.exists()}'."
     )
 
 


### PR DESCRIPTION
Pathlib is a new(-ish) standard library module (introduced 3.4) that provides a cleaner and more reliable way to handle file paths than the old os.path methods. They bake in OS-safety, adapting to Windows back-slashes and Unix forward-slashes seamlessly. Switching to Pathlib cleans up the code a little and avoids possible Windows problems.

Code by Phil Robare (@versilimidude2)