### PR TITLE
Fix bug in tutorial to calculate MRS with potential trade

### DIFF
--- a/examples/sugarscape_g1mt/run.py
+++ b/examples/sugarscape_g1mt/run.py
@@ -88,8 +88,8 @@ else:
     params = {
         "width": 50,
         "height": 50,
-        "vision_min": range(1, 3),
-        "metabolism_max": [3, 5],
+        "vision_min": range(1, 4),
+        "metabolism_max": [2, 3, 4, 5],
     }
 
     results_batch = mesa.batch_run(

--- a/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
+++ b/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
@@ -187,6 +187,24 @@ class SugarscapeG1mt(mesa.Model):
 
         # collect model level data
         self.datacollector.collect(self)
+        """
+        Mesa is working on updating datacollector agent reporter
+        so it can collect information on specific agents from
+        mesa.time.RandomActivationByType.
+
+        Please see issue #1419 at
+        https://github.com/projectmesa/mesa/issues/1419
+        (contributions welcome)
+
+        Below is one way to update agent_records to get specific Trader agent data
+        """
+        # Need to remove excess data
+        # Create local variable to store trade data
+        agent_trades = self.datacollector._agent_records[self.schedule.steps]
+        # Get rid of all None to reduce data storage needs
+        agent_trades = [agent for agent in agent_trades if agent[2] is not None]
+        # Reassign the dictionary value with lean trade data
+        self.datacollector._agent_records[self.schedule.steps] = agent_trades
 
     def run_model(self, step_count=1000):
         for i in range(step_count):

--- a/examples/sugarscape_g1mt/sugarscape_g1mt/trader_agents.py
+++ b/examples/sugarscape_g1mt/sugarscape_g1mt/trader_agents.py
@@ -140,16 +140,16 @@ class Trader(mesa.Agent):
 
         return (self.sugar <= 0) or (self.spice <= 0)
 
-    def calculate_MRS(self):
+    def calculate_MRS(self, sugar, spice):
         """
-        Helper function for self.trade()
+        Helper function for
+          - self.trade()
+          - self.maybe_self_spice()
 
-        Determines what trader agent is needs and can give up
+        Determines what trader agent needs and can give up
         """
 
-        return (self.spice / self.metabolism_spice) / (
-            self.sugar / self.metabolism_sugar
-        )
+        return (spice / self.metabolism_spice) / (sugar / self.metabolism_sugar)
 
     def calculate_sell_spice_amount(self, price):
         """
@@ -205,8 +205,10 @@ class Trader(mesa.Agent):
             welfare_self < self.calculate_welfare(self_sugar, self_spice)
         ) and (welfare_other < other.calculate_welfare(other_sugar, other_spice))
 
-        # trade criteria #2 is their mrs crossing
-        mrs_not_crossing = self.calculate_MRS() > other.calculate_MRS()
+        # trade criteria #2 is their mrs crossing with potential trade
+        mrs_not_crossing = self.calculate_MRS(
+            self_sugar, self_spice
+        ) > other.calculate_MRS(other_sugar, other_spice)
 
         if not (both_agents_better_off and mrs_not_crossing):
             return False
@@ -229,9 +231,9 @@ class Trader(mesa.Agent):
         assert other.sugar > 0
         assert other.spice > 0
 
-        # calculate marginal rate of subsitution in Growing Artificial Socieites p. 101
-        mrs_self = self.calculate_MRS()
-        mrs_other = other.calculate_MRS()
+        # calculate marginal rate of substitution in Growing Artificial Societies p. 101
+        mrs_self = self.calculate_MRS(self.sugar, self.spice)
+        mrs_other = other.calculate_MRS(other.sugar, other.spice)
 
         # calculate each agents welfare
         welfare_self = self.calculate_welfare(self.sugar, self.spice)


### PR DESCRIPTION
- update maybe_sell_spice() so calculate_MRS() takes potential sugar and spice based on trade
- update calculate_MRS() with kwargs so it can take potential trade but defaults to agents sugar and spice 
Update increases agent_reporter due to number of trades creating memory issues
- Update data collection so non-relevant data rmeoved on each step (i.e. sugar and spice agents don't have trade partners)