### PR TITLE
feat: Create mesa-models as a package

### DIFF
--- a/examples/boid_flockers/boid_flockers/model.py
+++ b/examples/boid_flockers/boid_flockers/model.py
@@ -67,7 +67,7 @@ class BoidFlockers(mesa.Model):
                 velocity,
                 self.vision,
                 self.separation,
-                **self.factors
+                **self.factors,
             )
             self.space.place_agent(boid, pos)
             self.schedule.add(boid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "mesa-models"
+version = "0.1.0"
+description = "Importable Mesa models."
+authors = [
+    {name = "Project Mesa Team", email = "projectmesa@googlegroups.com"}
+]
+license = {file = "LICENSE"}
+readme = "README.rst"
+requires-python = ">=3.8"
+dependencies = [
+    "mesa>=1.2"
+]
+
+
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[options]
+package_dir =
+    mesa_models.boltzmann_wealth_model = examples/boltzmann_wealth_model/boltzmann_wealth_model


### PR DESCRIPTION
Only `boltzmann_wealth_model` is enabled right now.
To use this, install the package, and do
```python
from mesa_models.boltzmann_wealth_model import model
model.compute_gini
```