### PR TITLE
Bug fixes and additions to Epstein Civil Violence

### DIFF
--- a/examples/epstein_civil_violence/epstein_civil_violence/agent.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/agent.py
@@ -78,14 +78,9 @@ class Citizen(mesa.Agent):
         self.update_neighbors()
         self.update_estimated_arrest_probability()
         net_risk = self.risk_aversion * self.arrest_probability
-        if (
-            self.condition == "Quiescent"
-            and (self.grievance - net_risk) > self.threshold
-        ):
+        if self.grievance - net_risk > self.threshold:
             self.condition = "Active"
-        elif (
-            self.condition == "Active" and (self.grievance - net_risk) <= self.threshold
-        ):
+        else:
             self.condition = "Quiescent"
         if self.model.movement and self.empty_neighbors:
             new_pos = self.random.choice(self.empty_neighbors)
@@ -96,7 +91,7 @@ class Citizen(mesa.Agent):
         Look around and see who my neighbors are
         """
         self.neighborhood = self.model.grid.get_neighborhood(
-            self.pos, moore=False, radius=1
+            self.pos, moore=True, radius=self.vision
         )
         self.neighbors = self.model.grid.get_cell_list_contents(self.neighborhood)
         self.empty_neighbors = [
@@ -118,7 +113,9 @@ class Citizen(mesa.Agent):
             ):
                 actives_in_vision += 1
         self.arrest_probability = 1 - math.exp(
-            -1 * self.model.arrest_prob_constant * (cops_in_vision / actives_in_vision)
+            -1
+            * self.model.arrest_prob_constant
+            * (cops_in_vision / actives_in_vision)
         )
 
 
@@ -167,6 +164,7 @@ class Cop(mesa.Agent):
             arrestee = self.random.choice(active_neighbors)
             sentence = self.random.randint(0, self.model.max_jail_term)
             arrestee.jail_sentence = sentence
+            arrestee.condition = "Quiescent"
         if self.model.movement and self.empty_neighbors:
             new_pos = self.random.choice(self.empty_neighbors)
             self.model.grid.move_agent(self, new_pos)
@@ -176,7 +174,7 @@ class Cop(mesa.Agent):
         Look around and see who my neighbors are.
         """
         self.neighborhood = self.model.grid.get_neighborhood(
-            self.pos, moore=False, radius=1
+            self.pos, moore=True, radius=self.vision
         )
         self.neighbors = self.model.grid.get_cell_list_contents(self.neighborhood)
         self.empty_neighbors = [

--- a/examples/epstein_civil_violence/epstein_civil_violence/agent.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/agent.py
@@ -113,7 +113,9 @@ class Citizen(mesa.Agent):
             ):
                 actives_in_vision += 1
         self.arrest_probability = 1 - math.exp(
-            -1 * self.model.arrest_prob_constant * (cops_in_vision / actives_in_vision)
+            -1
+            * self.model.arrest_prob_constant
+            * (cops_in_vision / actives_in_vision)
         )
 
 

--- a/examples/epstein_civil_violence/epstein_civil_violence/agent.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/agent.py
@@ -113,9 +113,7 @@ class Citizen(mesa.Agent):
             ):
                 actives_in_vision += 1
         self.arrest_probability = 1 - math.exp(
-            -1
-            * self.model.arrest_prob_constant
-            * (cops_in_vision / actives_in_vision)
+            -1 * self.model.arrest_prob_constant * (cops_in_vision / actives_in_vision)
         )
 
 

--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -104,8 +104,6 @@ class EpsteinCivilViolence(mesa.Model):
 
         self.running = True
         self.datacollector.collect(self)
-        self.citizen_count = sum(value for value in self.count_agents(self).values())
-        self.cop_count = self.count_cops(self)
 
     def step(self):
         """
@@ -142,17 +140,6 @@ class EpsteinCivilViolence(mesa.Model):
         count = 0
         for agent in model.schedule.agents:
             if agent.breed == "citizen" and agent.jail_sentence > 0:
-                count += 1
-        return count
-
-    @staticmethod
-    def count_cops(model):
-        """
-        Helper method to count cops.
-        """
-        count = 0
-        for agent in model.schedule.agents:
-            if agent.breed == "cop":
                 count += 1
         return count
 

--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -61,19 +61,10 @@ class EpsteinCivilViolence(mesa.Model):
         self.schedule = mesa.time.RandomActivation(self)
         self.grid = mesa.space.SingleGrid(width, height, torus=True)
 
-        # agent counts
-        self.citizen_count = 0
-        self.cop_count = 0
-        self.jail_count = 0
-        self.active_count = 0
-        self.quiescent_count = 0
-        self.average_jail_term = 0
-
         model_reporters = {
             "Quiescent": lambda m: self.count_type_citizens(m, "Quiescent"),
             "Active": lambda m: self.count_type_citizens(m, "Active"),
             "Jailed": self.count_jailed,
-            "Citizens": self.count_citizens,
             "Cops": self.count_cops,
         }
         agent_reporters = {
@@ -123,10 +114,6 @@ class EpsteinCivilViolence(mesa.Model):
         self.schedule.step()
         # collect data
         self.datacollector.collect(self)
-        # update agent counts
-        self.active_count = self.count_type_citizens(self, "Active")
-        self.quiescent_count = self.count_type_citizens(self, "Quiescent")
-        self.jail_count = self.count_jailed(self)
         # update iteration
         self.iteration += 1
         if self.iteration > self.max_iters:
@@ -155,17 +142,6 @@ class EpsteinCivilViolence(mesa.Model):
         count = 0
         for agent in model.schedule.agents:
             if agent.breed == "citizen" and agent.jail_sentence > 0:
-                count += 1
-        return count
-
-    @staticmethod
-    def count_citizens(model):
-        """
-        Helper method to count citizens.
-        """
-        count = 0
-        for agent in model.schedule.agents:
-            if agent.breed == "citizen":
                 count += 1
         return count
 

--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -141,15 +141,3 @@ class EpsteinCivilViolence(mesa.Model):
             if agent.breed == "citizen" and agent.jail_sentence > 0:
                 count += 1
         return count
-
-    # combine all agent counts into one method
-    @staticmethod
-    def count_agents(model):
-        """
-        combines the various count methods into one
-        """
-        return {
-            "Quiescent": model.count_type_citizens(model, "Quiescent"),
-            "Active": model.count_type_citizens(model, "Active"),
-            "Jailed": model.count_jailed(model),
-        }

--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -112,7 +112,6 @@ class EpsteinCivilViolence(mesa.Model):
         self.schedule.step()
         # collect data
         self.datacollector.collect(self)
-        # update iteration
         self.iteration += 1
         if self.iteration > self.max_iters:
             self.running = False

--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -60,10 +60,21 @@ class EpsteinCivilViolence(mesa.Model):
         self.iteration = 0
         self.schedule = mesa.time.RandomActivation(self)
         self.grid = mesa.space.SingleGrid(width, height, torus=True)
+
+        # agent counts
+        self.citizen_count = 0
+        self.cop_count = 0
+        self.jail_count = 0
+        self.active_count = 0
+        self.quiescent_count = 0
+        self.average_jail_term = 0
+
         model_reporters = {
             "Quiescent": lambda m: self.count_type_citizens(m, "Quiescent"),
             "Active": lambda m: self.count_type_citizens(m, "Active"),
             "Jailed": self.count_jailed,
+            "Citizens": self.count_citizens,
+            "Cops": self.count_cops,
         }
         agent_reporters = {
             "x": lambda a: a.pos[0],
@@ -102,6 +113,8 @@ class EpsteinCivilViolence(mesa.Model):
 
         self.running = True
         self.datacollector.collect(self)
+        self.citizen_count = sum(value for value in self.count_agents(self).values())
+        self.cop_count = self.count_cops(self)
 
     def step(self):
         """
@@ -110,6 +123,11 @@ class EpsteinCivilViolence(mesa.Model):
         self.schedule.step()
         # collect data
         self.datacollector.collect(self)
+        # update agent counts
+        self.active_count = self.count_type_citizens(self, "Active")
+        self.quiescent_count = self.count_type_citizens(self, "Quiescent")
+        self.jail_count = self.count_jailed(self)
+        # update iteration
         self.iteration += 1
         if self.iteration > self.max_iters:
             self.running = False
@@ -123,7 +141,7 @@ class EpsteinCivilViolence(mesa.Model):
         for agent in model.schedule.agents:
             if agent.breed == "cop":
                 continue
-            if exclude_jailed and agent.jail_sentence:
+            if exclude_jailed and agent.jail_sentence > 0:
                 continue
             if agent.condition == condition:
                 count += 1
@@ -136,6 +154,40 @@ class EpsteinCivilViolence(mesa.Model):
         """
         count = 0
         for agent in model.schedule.agents:
-            if agent.breed == "citizen" and agent.jail_sentence:
+            if agent.breed == "citizen" and agent.jail_sentence > 0:
                 count += 1
         return count
+
+    @staticmethod
+    def count_citizens(model):
+        """
+        Helper method to count citizens.
+        """
+        count = 0
+        for agent in model.schedule.agents:
+            if agent.breed == "citizen":
+                count += 1
+        return count
+
+    @staticmethod
+    def count_cops(model):
+        """
+        Helper method to count cops.
+        """
+        count = 0
+        for agent in model.schedule.agents:
+            if agent.breed == "cop":
+                count += 1
+        return count
+
+    # combine all agent counts into one method
+    @staticmethod
+    def count_agents(model):
+        """
+        combines the various count methods into one
+        """
+        return {
+            "Quiescent": model.count_type_citizens(model, "Quiescent"),
+            "Active": model.count_type_citizens(model, "Active"),
+            "Jailed": model.count_jailed(model),
+        }

--- a/examples/epstein_civil_violence/epstein_civil_violence/server.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/server.py
@@ -1,12 +1,24 @@
 import mesa
+from mesa.visualization.UserParam import Slider
+from mesa.visualization.modules import ChartModule
 
 from .agent import Citizen, Cop
 from .model import EpsteinCivilViolence
 
 COP_COLOR = "#000000"
-AGENT_QUIET_COLOR = "#0066CC"
-AGENT_REBEL_COLOR = "#CC0000"
-JAIL_COLOR = "#757575"
+AGENT_QUIET_COLOR = "#648FFF"
+AGENT_REBEL_COLOR = "#FE6100"
+JAIL_COLOR = "#808080"
+JAIL_SHAPE = "rect"
+
+chart = ChartModule(
+    [
+        {"Label": "Quiescent", "Color": "#648FFF"},
+        {"Label": "Active", "Color": "#FE6100"},
+        {"Label": "Jailed", "Color": "#808080"},
+    ],
+    data_collector_name="datacollector",
+)
 
 
 def citizen_cop_portrayal(agent):
@@ -25,29 +37,42 @@ def citizen_cop_portrayal(agent):
             AGENT_QUIET_COLOR if agent.condition == "Quiescent" else AGENT_REBEL_COLOR
         )
         color = JAIL_COLOR if agent.jail_sentence else color
+        shape = JAIL_SHAPE if agent.jail_sentence else "circle"
         portrayal["Color"] = color
-        portrayal["r"] = 0.8
+        portrayal["Shape"] = shape
+        if shape == "rect":
+            portrayal["w"] = 0.9
+            portrayal["h"] = 0.9
+        else:
+            portrayal["r"] = 0.5
+            portrayal["Filled"] = "false"
         portrayal["Layer"] = 0
 
     elif type(agent) is Cop:
         portrayal["Color"] = COP_COLOR
-        portrayal["r"] = 0.5
+        portrayal["r"] = 0.9
         portrayal["Layer"] = 1
+
     return portrayal
 
 
-model_params = {
-    "height": 40,
-    "width": 40,
-    "citizen_density": 0.7,
-    "cop_density": 0.074,
-    "citizen_vision": 7,
-    "cop_vision": 7,
-    "legitimacy": 0.8,
-    "max_jail_term": 1000,
-}
-
+model_params = dict(
+    height=40,
+    width=40,
+    citizen_density=Slider("Initial Agent Density", 0.7, 0.0, 0.9, 0.1),
+    cop_density=Slider("Initial Cop Density", 0.04, 0.0, 0.1, 0.01),
+    citizen_vision=Slider("Citizen Vision", 7, 1, 10, 1),
+    cop_vision=Slider("Cop Vision", 7, 1, 10, 1),
+    legitimacy=Slider("Government Legitimacy", 0.82, 0.0, 1, 0.01),
+    max_jail_term=Slider("Max Jail Term", 30, 0, 50, 1),
+)
 canvas_element = mesa.visualization.CanvasGrid(citizen_cop_portrayal, 40, 40, 480, 480)
 server = mesa.visualization.ModularServer(
-    EpsteinCivilViolence, [canvas_element], "Epstein Civil Violence", model_params
+    EpsteinCivilViolence,
+    [
+        canvas_element,
+        chart,
+    ],
+    "Epstein Civil Violence",
+    model_params,
 )

--- a/examples/epstein_civil_violence/epstein_civil_violence/server.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/server.py
@@ -1,6 +1,6 @@
 import mesa
-from mesa.visualization.UserParam import Slider
 from mesa.visualization.modules import ChartModule
+from mesa.visualization.UserParam import Slider
 
 from .agent import Citizen, Cop
 from .model import EpsteinCivilViolence
@@ -56,16 +56,16 @@ def citizen_cop_portrayal(agent):
     return portrayal
 
 
-model_params = dict(
-    height=40,
-    width=40,
-    citizen_density=Slider("Initial Agent Density", 0.7, 0.0, 0.9, 0.1),
-    cop_density=Slider("Initial Cop Density", 0.04, 0.0, 0.1, 0.01),
-    citizen_vision=Slider("Citizen Vision", 7, 1, 10, 1),
-    cop_vision=Slider("Cop Vision", 7, 1, 10, 1),
-    legitimacy=Slider("Government Legitimacy", 0.82, 0.0, 1, 0.01),
-    max_jail_term=Slider("Max Jail Term", 30, 0, 50, 1),
-)
+model_params = {
+    "height": 40,
+    "width": 40,
+    "citizen_density": Slider("Initial Agent Density", 0.7, 0.0, 0.9, 0.1),
+    "cop_density": Slider("Initial Cop Density", 0.04, 0.0, 0.1, 0.01),
+    "citizen_vision": Slider("Citizen Vision", 7, 1, 10, 1),
+    "cop_vision": Slider("Cop Vision", 7, 1, 10, 1),
+    "legitimacy": Slider("Government Legitimacy", 0.82, 0.0, 1, 0.01),
+    "max_jail_term": Slider("Max Jail Term", 30, 0, 50, 1),
+}
 canvas_element = mesa.visualization.CanvasGrid(citizen_cop_portrayal, 40, 40, 480, 480)
 server = mesa.visualization.ModularServer(
     EpsteinCivilViolence,

--- a/examples/epstein_civil_violence/epstein_civil_violence/server.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/server.py
@@ -1,6 +1,4 @@
 import mesa
-from mesa.visualization.modules import ChartModule
-from mesa.visualization.UserParam import Slider
 
 from .agent import Citizen, Cop
 from .model import EpsteinCivilViolence
@@ -10,15 +8,6 @@ AGENT_QUIET_COLOR = "#648FFF"
 AGENT_REBEL_COLOR = "#FE6100"
 JAIL_COLOR = "#808080"
 JAIL_SHAPE = "rect"
-
-chart = ChartModule(
-    [
-        {"Label": "Quiescent", "Color": "#648FFF"},
-        {"Label": "Active", "Color": "#FE6100"},
-        {"Label": "Jailed", "Color": "#808080"},
-    ],
-    data_collector_name="datacollector",
-)
 
 
 def citizen_cop_portrayal(agent):
@@ -59,14 +48,28 @@ def citizen_cop_portrayal(agent):
 model_params = {
     "height": 40,
     "width": 40,
-    "citizen_density": Slider("Initial Agent Density", 0.7, 0.0, 0.9, 0.1),
-    "cop_density": Slider("Initial Cop Density", 0.04, 0.0, 0.1, 0.01),
-    "citizen_vision": Slider("Citizen Vision", 7, 1, 10, 1),
-    "cop_vision": Slider("Cop Vision", 7, 1, 10, 1),
-    "legitimacy": Slider("Government Legitimacy", 0.82, 0.0, 1, 0.01),
-    "max_jail_term": Slider("Max Jail Term", 30, 0, 50, 1),
+    "citizen_density": mesa.visualization.Slider(
+        "Initial Agent Density", 0.7, 0.0, 0.9, 0.1
+    ),
+    "cop_density": mesa.visualization.Slider(
+        "Initial Cop Density", 0.04, 0.0, 0.1, 0.01
+    ),
+    "citizen_vision": mesa.visualization.Slider("Citizen Vision", 7, 1, 10, 1),
+    "cop_vision": mesa.visualization.Slider("Cop Vision", 7, 1, 10, 1),
+    "legitimacy": mesa.visualization.Slider(
+        "Government Legitimacy", 0.82, 0.0, 1, 0.01
+    ),
+    "max_jail_term": mesa.visualization.Slider("Max Jail Term", 30, 0, 50, 1),
 }
 canvas_element = mesa.visualization.CanvasGrid(citizen_cop_portrayal, 40, 40, 480, 480)
+chart = mesa.visualization.ChartModule(
+    [
+        {"Label": "Quiescent", "Color": "#648FFF"},
+        {"Label": "Active", "Color": "#FE6100"},
+        {"Label": "Jailed", "Color": "#808080"},
+    ],
+    data_collector_name="datacollector",
+)
 server = mesa.visualization.ModularServer(
     EpsteinCivilViolence,
     [


### PR DESCRIPTION
This update changes a small set of bugs that was causing the model to not exhibit the cyclical explosions of active agents seen in the original Epstein paper. It also adds some small functionality to the browser display, introducing sliders to allow the user to change model parameters on the fly, and watch a graph of agent state numbers.

Bug Fixes
- Fix agent state logic
- Fix Moore vs Von Neuman neighborhood selection to use Epstein paper behavior
- Fix agent vision bug (was 1 and not parameter `vision` when calculating neighborhood, which also fixes agent movement issue)
- Fix arrestee state issue (arrestee was not being reset to "Quiescent", and so was counting as "Active" for all nearby agents)

Additions and Changes
- add model attributes to count agents and display a graph of agent states
- Change display of agents where jailed agents are represented by grey square box
- Added sliders for model attributes