### PR TITLE
jupyter viz: Allow for custom space drawer

### DIFF
--- a/experimental/jupyter_viz.py
+++ b/experimental/jupyter_viz.py
@@ -195,9 +195,9 @@ def MesaComponent(viz):
         # solara.Button(label="Reset", color="primary", on_click=do_reset)
 
     with solara.GridFixed(columns=2):
-        # 3. Space
+        # 4. Space
         make_space(viz)
-        # 4. Plots
+        # 5. Plots
         for i, measure in enumerate(viz.measures):
             if callable(measure):
                 # Is a custom object

--- a/experimental/jupyter_viz.py
+++ b/experimental/jupyter_viz.py
@@ -136,7 +136,7 @@ def make_user_input(user_input, k, v):
 
 
 @solara.component
-def MesaComponent(viz):
+def MesaComponent(viz, space_drawer=None, play_interval=400):
     solara.Markdown(viz.name)
 
     # 1. User inputs
@@ -178,7 +178,7 @@ def MesaComponent(viz):
         )
         widgets.Play(
             value=0,
-            interval=400,
+            interval=play_interval,
             repeat=True,
             show_repeat=False,
             on_value=on_value_play,
@@ -196,7 +196,10 @@ def MesaComponent(viz):
 
     with solara.GridFixed(columns=2):
         # 4. Space
-        make_space(viz)
+        if space_drawer is None:
+            make_space(viz)
+        else:
+            space_drawer(viz)
         # 5. Plots
         for i, measure in enumerate(viz.measures):
             if callable(measure):
@@ -207,8 +210,16 @@ def MesaComponent(viz):
 
 
 def JupyterViz(
-    model_class, model_params, measures=None, name="Mesa Model", agent_portrayal=None
+    model_class,
+    model_params,
+    measures=None,
+    name="Mesa Model",
+    agent_portrayal=None,
+    space_drawer=None,
+    play_interval=400,
 ):
     return MesaComponent(
-        JupyterContainer(model_class, model_params, measures, name, agent_portrayal)
+        JupyterContainer(model_class, model_params, measures, name, agent_portrayal),
+        space_drawer=space_drawer,
+        play_interval=play_interval,
     )

--- a/experimental/jupyter_viz.py
+++ b/experimental/jupyter_viz.py
@@ -167,6 +167,8 @@ def MesaComponent(viz):
 
     with solara.Row():
         solara.Button(label="Step", color="primary", on_click=viz.do_step)
+        # This style is necessary so that the play widget has almost the same
+        # height as typical Solara buttons.
         solara.Style(
             """
         .widget-play {


### PR DESCRIPTION
This is necessary to draw multiple "layers" for the trading Sugarscape. I will open the PR that implements Jupyter viz for trading Sugarscape after this one has been merged.