### PR TITLE
bugfix: Added count_cops method to the model

### DIFF
--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -141,3 +141,14 @@ class EpsteinCivilViolence(mesa.Model):
             if agent.breed == "citizen" and agent.jail_sentence > 0:
                 count += 1
         return count
+
+    @staticmethod
+    def count_cops(model):
+        """
+        Helper method to count jailed agents.
+        """
+        count = 0
+        for agent in model.schedule.agents:
+            if agent.breed == "cop":
+                count += 1
+        return count


### PR DESCRIPTION
### Missing method

The example is missing the `count_cops` abstract method in the file `examples/epstein_civil_violence/epstein_civil_violence/model.py`.

The model execution was failing due to the method not being implemented. Now is working