### PR TITLE
Test examples

### DIFF
--- a/examples/bank_reserves/bank_reserves/agents.py
+++ b/examples/bank_reserves/bank_reserves/agents.py
@@ -11,6 +11,7 @@ Author of NetLogo code:
 """
 
 import mesa
+
 from .random_walk import RandomWalker
 
 

--- a/examples/bank_reserves/bank_reserves/agents.py
+++ b/examples/bank_reserves/bank_reserves/agents.py
@@ -11,7 +11,7 @@ Author of NetLogo code:
 """
 
 import mesa
-from bank_reserves.random_walk import RandomWalker
+from .random_walk import RandomWalker
 
 
 class Bank(mesa.Agent):

--- a/examples/bank_reserves/bank_reserves/model.py
+++ b/examples/bank_reserves/bank_reserves/model.py
@@ -12,6 +12,7 @@ Author of NetLogo code:
 
 import mesa
 import numpy as np
+
 from .agents import Bank, Person
 
 """

--- a/examples/bank_reserves/bank_reserves/model.py
+++ b/examples/bank_reserves/bank_reserves/model.py
@@ -12,7 +12,7 @@ Author of NetLogo code:
 
 import mesa
 import numpy as np
-from bank_reserves.agents import Bank, Person
+from .agents import Bank, Person
 
 """
 If you want to perform a parameter sweep, call batch_run.py instead of run.py.

--- a/examples/bank_reserves/bank_reserves/server.py
+++ b/examples/bank_reserves/bank_reserves/server.py
@@ -1,4 +1,5 @@
 import mesa
+
 from .agents import Person
 from .model import BankReserves
 

--- a/examples/bank_reserves/bank_reserves/server.py
+++ b/examples/bank_reserves/bank_reserves/server.py
@@ -1,6 +1,6 @@
 import mesa
-from bank_reserves.agents import Person
-from bank_reserves.model import BankReserves
+from .agents import Person
+from .model import BankReserves
 
 """
 Citation:

--- a/examples/charts/charts/agents.py
+++ b/examples/charts/charts/agents.py
@@ -11,6 +11,7 @@ Author of NetLogo code:
 """
 
 import mesa
+
 from .random_walk import RandomWalker
 
 

--- a/examples/charts/charts/agents.py
+++ b/examples/charts/charts/agents.py
@@ -11,7 +11,7 @@ Author of NetLogo code:
 """
 
 import mesa
-from charts.random_walk import RandomWalker
+from .random_walk import RandomWalker
 
 
 class Bank(mesa.Agent):

--- a/examples/charts/charts/model.py
+++ b/examples/charts/charts/model.py
@@ -12,6 +12,7 @@ Author of NetLogo code:
 
 import mesa
 import numpy as np
+
 from .agents import Bank, Person
 
 """

--- a/examples/charts/charts/model.py
+++ b/examples/charts/charts/model.py
@@ -12,7 +12,7 @@ Author of NetLogo code:
 
 import mesa
 import numpy as np
-from charts.agents import Bank, Person
+from .agents import Bank, Person
 
 """
 If you want to perform a parameter sweep, call batch_run.py instead of run.py.

--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -141,3 +141,14 @@ class EpsteinCivilViolence(mesa.Model):
             if agent.breed == "citizen" and agent.jail_sentence > 0:
                 count += 1
         return count
+
+    @staticmethod
+    def count_cops(model):
+        """
+        Helper method to count jailed agents.
+        """
+        count = 0
+        for agent in model.schedule.agents:
+            if agent.breed == "cop":
+                count += 1
+        return count

--- a/examples/hex_snowflake/hex_snowflake/model.py
+++ b/examples/hex_snowflake/hex_snowflake/model.py
@@ -1,4 +1,5 @@
 import mesa
+
 from .cell import Cell
 
 

--- a/examples/hex_snowflake/hex_snowflake/model.py
+++ b/examples/hex_snowflake/hex_snowflake/model.py
@@ -1,5 +1,5 @@
 import mesa
-from hex_snowflake.cell import Cell
+from .cell import Cell
 
 
 class HexSnowflake(mesa.Model):
@@ -22,7 +22,7 @@ class HexSnowflake(mesa.Model):
         self.schedule = mesa.time.SimultaneousActivation(self)
 
         # Use a hexagonal grid, where edges wrap around.
-        self.grid = mesa.space.HexGrid(width, height, torus=True)
+        self.grid = mesa.space.HexSingleGrid(width, height, torus=True)
 
         # Place a dead cell at each location.
         for contents, pos in self.grid.coord_iter():

--- a/examples/sugarscape_cg/sugarscape_cg/model.py
+++ b/examples/sugarscape_cg/sugarscape_cg/model.py
@@ -10,6 +10,7 @@ Northwestern University, Evanston, IL.
 """
 
 import mesa
+from pathlib import Path
 
 from .agents import SsAgent, Sugar
 
@@ -43,7 +44,7 @@ class SugarscapeCg(mesa.Model):
         # Create sugar
         import numpy as np
 
-        sugar_distribution = np.genfromtxt("sugarscape_cg/sugar-map.txt")
+        sugar_distribution = np.genfromtxt(Path(__file__).parent / "sugar-map.txt")
         agent_id = 0
         for _, (x, y) in self.grid.coord_iter():
             max_sugar = sugar_distribution[x, y]

--- a/examples/sugarscape_cg/sugarscape_cg/model.py
+++ b/examples/sugarscape_cg/sugarscape_cg/model.py
@@ -9,8 +9,9 @@ Center for Connected Learning and Computer-Based Modeling,
 Northwestern University, Evanston, IL.
 """
 
-import mesa
 from pathlib import Path
+
+import mesa
 
 from .agents import SsAgent, Sugar
 

--- a/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
+++ b/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import mesa
 import numpy as np
 

--- a/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
+++ b/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import mesa
 import numpy as np
 
@@ -85,7 +86,7 @@ class SugarscapeG1mt(mesa.Model):
         )
 
         # read in landscape file from supplmentary material
-        sugar_distribution = np.genfromtxt("sugarscape_g1mt/sugar-map.txt")
+        sugar_distribution = np.genfromtxt(Path(__file__).parent / "sugar-map.txt")
         spice_distribution = np.flip(sugar_distribution, 1)
 
         agent_id = 0

--- a/examples/wolf_sheep/wolf_sheep/server.py
+++ b/examples/wolf_sheep/wolf_sheep/server.py
@@ -1,5 +1,4 @@
 import mesa
-
 from wolf_sheep.agents import GrassPatch, Sheep, Wolf
 from wolf_sheep.model import WolfSheep
 

--- a/examples/wolf_sheep/wolf_sheep/test_random_walk.py
+++ b/examples/wolf_sheep/wolf_sheep/test_random_walk.py
@@ -7,7 +7,6 @@ from mesa import Model
 from mesa.space import MultiGrid
 from mesa.time import RandomActivation
 from mesa.visualization.TextVisualization import TextGrid, TextVisualization
-
 from wolf_sheep.random_walk import RandomWalker
 
 

--- a/gis/agents_and_networks/src/visualization/server.py
+++ b/gis/agents_and_networks/src/visualization/server.py
@@ -8,7 +8,6 @@ from src.agent.geo_agents import Driveway, LakeAndRiver, Walkway
 class ClockElement(mesa.visualization.TextElement):
     def __init__(self):
         super().__init__()
-        pass
 
     def render(self, model):
         return f"Day {model.day}, {model.hour:02d}:{model.minute:02d}"

--- a/test_examples.py
+++ b/test_examples.py
@@ -1,0 +1,33 @@
+import pytest
+import os
+from mesa import Model
+import importlib
+
+
+def get_models(directory):
+    models = []
+    for root, dirs, files in os.walk(directory):
+        for file in files:
+            if file == "model.py":
+                module_name = os.path.relpath(os.path.join(root, file[:-3])).replace(
+                    os.sep, "."
+                )
+
+                module = importlib.import_module(module_name)
+                for item in dir(module):
+                    obj = getattr(module, item)
+                    if (
+                        isinstance(obj, type)
+                        and issubclass(obj, Model)
+                        and obj is not Model
+                    ):
+                        models.append(obj)
+
+    return models
+
+
+@pytest.mark.parametrize("model_class", get_models("examples"))
+def test_model_steps(model_class):
+    model = model_class()  # Assume no arguments are needed
+    for _ in range(10):
+        model.step()

--- a/test_examples.py
+++ b/test_examples.py
@@ -1,7 +1,8 @@
-import pytest
-import os
-from mesa import Model
 import importlib
+import os
+
+import pytest
+from mesa import Model
 
 
 def get_models(directory):


### PR DESCRIPTION
Added a test that initiales and runs each model for 10 steps. Currently only handles core examples, not geo examples. 

To make the test file run I had to modify some imports to be relative imports.

Otherwise this PR fixes 1 error and 1 warning:

In the epstein_civil_violence model the `count_cops` method was missing

The hexgrid examples used `HexGrid`, which is deprecated and should be changed to `HexGridSingle`.

