### PR TITLE
gis: update gis examples to use mesa-geo v0.6.0

### DIFF
--- a/gis/agents_and_networks/requirements.txt
+++ b/gis/agents_and_networks/requirements.txt
@@ -2,7 +2,7 @@
 -e .
 
 # external requirements
-mesa-geo~=0.5.0
+mesa-geo~=0.6.0
 geopandas
 numpy
 pandas

--- a/gis/geo_schelling/requirements.txt
+++ b/gis/geo_schelling/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.5.0
+mesa-geo~=0.6.0

--- a/gis/geo_schelling_points/requirements.txt
+++ b/gis/geo_schelling_points/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.5.0
+mesa-geo~=0.6.0

--- a/gis/geo_sir/requirements.txt
+++ b/gis/geo_sir/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.5.0
+mesa-geo~=0.6.0

--- a/gis/population/requirements.txt
+++ b/gis/population/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.5.0
+mesa-geo~=0.6.0

--- a/gis/rainfall/requirements.txt
+++ b/gis/rainfall/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.5.0
+mesa-geo~=0.6.0

--- a/gis/urban_growth/requirements.txt
+++ b/gis/urban_growth/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.5.0
+mesa-geo~=0.6.0


### PR DESCRIPTION
Update example dependency to mesa-geo v0.6.0. Closes #59.

Ready to merge once `mesa-viz-tornado` has a bug fix release (see https://github.com/projectmesa/mesa-viz-tornado/pull/37#issuecomment-1764013166).