### PR TITLE
gis: update examples for mesa-geo v0.7.0

### DIFF
--- a/gis/agents_and_networks/requirements.txt
+++ b/gis/agents_and_networks/requirements.txt
@@ -2,7 +2,7 @@
 -e .
 
 # external requirements
-mesa-geo~=0.6.0
+mesa-geo~=0.7
 geopandas
 numpy
 pandas

--- a/gis/geo_schelling/requirements.txt
+++ b/gis/geo_schelling/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.6.0
+mesa-geo~=0.7

--- a/gis/geo_schelling_points/requirements.txt
+++ b/gis/geo_schelling_points/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.6.0
+mesa-geo~=0.7

--- a/gis/geo_sir/model.py
+++ b/gis/geo_sir/model.py
@@ -103,8 +103,6 @@ class GeoSir(mesa.Model):
         self.steps += 1
         self.reset_counts()
         self.schedule.step()
-        # Recalculate spatial tree, because agents are moving
-        self.space._recreate_rtree()
 
         self.datacollector.collect(self)
 

--- a/gis/geo_sir/requirements.txt
+++ b/gis/geo_sir/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.6.0
+mesa-geo~=0.7

--- a/gis/population/requirements.txt
+++ b/gis/population/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.6.0
+mesa-geo~=0.7

--- a/gis/rainfall/requirements.txt
+++ b/gis/rainfall/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.6.0
+mesa-geo~=0.7

--- a/gis/urban_growth/requirements.txt
+++ b/gis/urban_growth/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.6.0
+mesa-geo~=0.7


### PR DESCRIPTION
- Update dependency to mesa-geo v0.7
- Spatial indexing is now taken care of in https://github.com/projectmesa/mesa-geo/pull/179. So it's not necessary to explicitly rebuild rtree index in the `geo_sir` example.