### PR TITLE
Fix two more cases of a missing super().__init__() in the model init

### DIFF
--- a/examples/boltzmann_wealth_model_experimental/model.py
+++ b/examples/boltzmann_wealth_model_experimental/model.py
@@ -18,6 +18,7 @@ class BoltzmannWealthModel(mesa.Model):
     """
 
     def __init__(self, N=100, width=10, height=10):
+        super().__init__()
         self.num_agents = N
         self.grid = mesa.space.MultiGrid(width, height, True)
         self.schedule = mesa.time.RandomActivation(self)

--- a/examples/caching_and_replay/model.py
+++ b/examples/caching_and_replay/model.py
@@ -41,7 +41,7 @@ class Schelling(mesa.Model):
 
     def __init__(self, width=20, height=20, density=0.8, minority_pc=0.2, homophily=3):
         """ """
-
+        super().__init__()
         self.width = width
         self.height = height
         self.density = density


### PR DESCRIPTION
Fixes two more cases of a missing super().__init__() in the model init. Should resolve two of the errors in https://github.com/projectmesa/mesa/pull/1942.