### PR TITLE
Publish sugarscape_cg to mesa_models

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ package_dir =
     mesa_models.schelling = examples/schelling
     mesa_models.epstein_civil_violence = examples/epstein_civil_violence/epstein_civil_violence
     mesa_models.wolf_sheep = examples/wolf_sheep/wolf_sheep
+    mesa_models.sugarscape_cg = examples/sugarscape_cg/sugarscape_cg


### PR DESCRIPTION
This is needed so that
https://github.com/projectmesa/mesa-examples/pull/106 can inherit from sugarscape_cg, to reduce code duplication.