### PR TITLE
CI: Add job to test against Mesa pre-releases

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -37,6 +37,21 @@ jobs:
     - name: Test with pytest
       run: pytest test_examples.py
 
+  build-pre:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        pip install mesa --pre
+        pip install pytest
+    - name: Test with pytest
+      run: pytest test_examples.py
+
   build-main:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add a job to the Mesa-examples CI configuration to explicitly test against Mesa pre-releases. This could help detect regressions between the stable release and latest pre-release, or between the latest pre-release and main branch.

It basically narrows the search range if one of jobs fail.