### PR TITLE
Use SolaraViz instead of JupyterViz in examples

### DIFF
--- a/examples/boid_flockers/app.py
+++ b/examples/boid_flockers/app.py
@@ -1,5 +1,5 @@
 from boid_flockers.model import BoidFlockers
-from mesa.experimental import JupyterViz
+from mesa.visualization import SolaraViz
 
 
 def boid_draw(agent):
@@ -15,7 +15,7 @@ model_params = {
     "separation": 2,
 }
 
-page = JupyterViz(
+page = SolaraViz(
     model_class=BoidFlockers,
     model_params=model_params,
     measures=[],

--- a/examples/boltzmann_wealth_model_experimental/app.py
+++ b/examples/boltzmann_wealth_model_experimental/app.py
@@ -1,4 +1,4 @@
-from mesa.experimental import JupyterViz
+from mesa.visualization import SolaraViz
 from model import BoltzmannWealthModel
 
 
@@ -24,7 +24,7 @@ model_params = {
     "height": 10,
 }
 
-page = JupyterViz(
+page = SolaraViz(
     BoltzmannWealthModel,
     model_params,
     measures=["Gini"],

--- a/examples/hotelling_law/app.py
+++ b/examples/hotelling_law/app.py
@@ -5,7 +5,7 @@ import solara
 from hotelling_law.agents import ConsumerAgent, StoreAgent
 from hotelling_law.model import HotellingModel
 from matplotlib.figure import Figure
-from mesa.experimental import JupyterViz
+from mesa.visualization import SolaraViz
 
 model_params = {
     "N_stores": {
@@ -340,8 +340,8 @@ def make_revenue_line_chart(model):
     return solara.FigureMatplotlib(fig)
 
 
-# Instantiate the JupyterViz component with your model
-page = JupyterViz(
+# Instantiate the SolaraViz component with your model
+page = SolaraViz(
     model_class=HotellingModel,
     model_params=model_params,
     measures=[

--- a/examples/schelling_experimental/app.py
+++ b/examples/schelling_experimental/app.py
@@ -1,4 +1,4 @@
-from mesa.visualization.jupyter_viz import JupyterViz, Slider, make_text
+from mesa.visualization.solara_viz.py import Slider, SolaraViz, make_text
 from model import Schelling
 
 
@@ -21,7 +21,7 @@ model_params = {
     "height": 20,
 }
 
-page = JupyterViz(
+page = SolaraViz(
     Schelling,
     model_params,
     measures=["happy", make_text(get_happy_agents)],

--- a/examples/sugarscape_g1mt/app.py
+++ b/examples/sugarscape_g1mt/app.py
@@ -1,7 +1,7 @@
 import numpy as np
 import solara
 from matplotlib.figure import Figure
-from mesa.experimental import JupyterViz
+from mesa.visualization import SolaraViz
 from sugarscape_g1mt.model import SugarscapeG1mt
 from sugarscape_g1mt.trader_agents import Trader
 
@@ -50,7 +50,7 @@ model_params = {
     "height": 50,
 }
 
-page = JupyterViz(
+page = SolaraViz(
     SugarscapeG1mt,
     model_params,
     measures=["Trader", "Price"],

--- a/examples/virus_on_network/app.py
+++ b/examples/virus_on_network/app.py
@@ -3,7 +3,7 @@ import math
 import solara
 from matplotlib.figure import Figure
 from matplotlib.ticker import MaxNLocator
-from mesa.experimental import JupyterViz, make_text
+from mesa.visualization import SolaraViz, make_text
 from virus_on_network.model import State, VirusOnNetwork, number_infected
 
 
@@ -119,7 +119,7 @@ model_params = {
     },
 }
 
-page = JupyterViz(
+page = SolaraViz(
     VirusOnNetwork,
     model_params,
     measures=[


### PR DESCRIPTION
This updates all the examples to use the renamed and stabilized SolaraViz.

For reference:
- https://github.com/projectmesa/mesa/pull/2090
- https://github.com/projectmesa/mesa/pull/2188