### PR TITLE
schelling_experimental: Remove temporary _advance_time() method

### DIFF
--- a/examples/schelling_experimental/model.py
+++ b/examples/schelling_experimental/model.py
@@ -66,8 +66,6 @@ class Schelling(mesa.Model):
         """
         self.happy = 0  # Reset counter of happy agents
         self.agents.shuffle().do("step")
-        # Must be before data collection.
-        self._advance_time()  # Temporary API; will be finalized by Mesa 3.0 release
         # collect data
         self.datacollector.collect(self)
 


### PR DESCRIPTION
Remove the remove temporary _advance_time() method from schelling_experimental. This isn't needed anymore, because in Mesa 3.0 time will be automatically increased.

See https://github.com/projectmesa/mesa/pull/2223.