### PR TITLE
Fix [issue #168] virus_on_network not updating

### DIFF
--- a/examples/virus_on_network/virus_on_network/model.py
+++ b/examples/virus_on_network/virus_on_network/model.py
@@ -97,6 +97,8 @@ class VirusOnNetwork(mesa.Model):
 
     def step(self):
         self.agents.shuffle().do("step")
+        # advance model time
+        self._advance_time()
         # collect data
         self.datacollector.collect(self)
 


### PR DESCRIPTION
As stated in [#168](https://github.com/projectmesa/mesa-examples/issues/168)   virus_on_network visualization does not update as the model advances. The issue is that SolaraViz watches `model._step` which doesn't advance in this model because the model doesn't use a scheduler.   This is fixed by calling `self._advance_time()` in `model:step()`.    This is a one line change.