### PR TITLE
Make GIS models testable and test in CI

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install mesa --pre
-        pip install pytest
+        pip install .[test]
     - name: Test with pytest
       run: pytest -rA -Werror test_examples.py
 
@@ -54,7 +54,7 @@ jobs:
         python-version: "3.12"
     - name: Install dependencies
       run: |
-        pip install pytest
+        pip install .[test]
         pip install -U git+https://github.com/projectmesa/mesa@main#egg=mesa
     - name: Test with pytest
       run: pytest -rA -Werror test_examples.py

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -1,27 +1,19 @@
-name: build
+name: Test example models
 
 on:
   push:
-    branches:
-    - main
-    - release**
-    paths-ignore:
-      - '**.md'
-      - '**.rst'
+    paths:
+      - 'examples/**/*.py'  # If an example model is modified
+      - 'test_examples.py'  # If the test script is modified
+      - '.github/workflows/test_examples.yml'  # If this workflow is modified
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.rst'
+    paths:
+      - 'examples/**/*.py'
+      - 'test_examples.py'
+      - '.github/workflows/test_examples.yml'
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'  # Monday at 6:00 UTC
-
-# This will cancel previous run if a newer job that obsoletes the said previous
-# run, is started.
-# Based on https://github.com/zulip/zulip/commit/4a11642cee3c8aec976d305d51a86e60e5d70522
-concurrency:
-  group: "${{ github.workflow }}-${{ github.head_ref || github.run_id }}"
-  cancel-in-progress: true
 
 jobs:
   # build-stable:

--- a/.github/workflows/test_gis_examples.yml
+++ b/.github/workflows/test_gis_examples.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install mesa mesa-geo --pre
-        pip install 
+        pip install .[test_gis]
         pip install pytest
     - name: Test with pytest
       run: pytest -rA -Werror test_gis_examples.py

--- a/.github/workflows/test_gis_examples.yml
+++ b/.github/workflows/test_gis_examples.yml
@@ -39,9 +39,8 @@ jobs:
         python-version: "3.12"
     - name: Install dependencies
       run: |
-        pip install mesa mesa-geo --pre
+        pip install mesa-geo --pre
         pip install .[test_gis]
-        pip install pytest
     - name: Test with pytest
       run: pytest -rA -Werror test_gis_examples.py
 
@@ -55,8 +54,7 @@ jobs:
         python-version: "3.12"
     - name: Install dependencies
       run: |
-        pip install pytest
-        pip install -U git+https://github.com/projectmesa/mesa@main#egg=mesa
         pip install -U git+https://github.com/projectmesa/mesa-geo@main#egg=mesa-geo
+        pip install .[test_gis]
     - name: Test with pytest
       run: pytest -rA -Werror test_gis_examples.py

--- a/.github/workflows/test_gis_examples.yml
+++ b/.github/workflows/test_gis_examples.yml
@@ -1,0 +1,62 @@
+name: Test GIS models
+
+on:
+  push:
+    paths:
+      - 'gis/**/*.py'  # If a gis model is modified
+      - 'test_gis_examples.py'  # If the gis test script is modified
+      - '.github/workflows/test_gis_examples.yml'  # If this workflow is modified
+  pull_request:
+    paths:
+      - 'gis/**/*.py'
+      - 'test_gis_examples.py'
+      - '.github/workflows/test_gis_examples.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # Monday at 6:00 UTC
+
+jobs:
+  # build-stable:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: "3.12"
+  #   - name: Install dependencies
+  #     run: pip install mesa pytest
+  #   - name: Test with pytest
+  #     run: pytest -rA -Werror test_examples.py
+
+  build-pre:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        pip install mesa mesa-geo --pre
+        pip install 
+        pip install pytest
+    - name: Test with pytest
+      run: pytest -rA -Werror test_gis_examples.py
+
+  build-main:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        pip install pytest
+        pip install -U git+https://github.com/projectmesa/mesa@main#egg=mesa
+        pip install -U git+https://github.com/projectmesa/mesa-geo@main#egg=mesa-geo
+    - name: Test with pytest
+      run: pytest -rA -Werror test_gis_examples.py

--- a/gis/agents_and_networks/src/agent/commuter.py
+++ b/gis/agents_and_networks/src/agent/commuter.py
@@ -8,8 +8,8 @@ import numpy as np
 import pyproj
 from shapely.geometry import LineString, Point
 
-from src.agent.building import Building
-from src.space.utils import UnitTransformer, redistribute_vertices
+from ..space.utils import UnitTransformer, redistribute_vertices
+from .building import Building
 
 
 class Commuter(mg.GeoAgent):

--- a/gis/agents_and_networks/src/model/model.py
+++ b/gis/agents_and_networks/src/model/model.py
@@ -7,11 +7,11 @@ import mesa_geo as mg
 import pandas as pd
 from shapely.geometry import Point
 
-from src.agent.building import Building
-from src.agent.commuter import Commuter
-from src.agent.geo_agents import Driveway, LakeAndRiver, Walkway
-from src.space.campus import Campus
-from src.space.road_network import CampusWalkway
+from ..agent.building import Building
+from ..agent.commuter import Commuter
+from ..agent.geo_agents import Driveway, LakeAndRiver, Walkway
+from ..space.campus import Campus
+from ..space.road_network import CampusWalkway
 
 
 def get_time(model) -> pd.Timedelta:

--- a/gis/agents_and_networks/src/space/campus.py
+++ b/gis/agents_and_networks/src/space/campus.py
@@ -6,8 +6,8 @@ import mesa
 import mesa_geo as mg
 from shapely.geometry import Point
 
-from src.agent.building import Building
-from src.agent.commuter import Commuter
+from ..agent.building import Building
+from ..agent.commuter import Commuter
 
 
 class Campus(mg.GeoSpace):

--- a/gis/agents_and_networks/src/space/road_network.py
+++ b/gis/agents_and_networks/src/space/road_network.py
@@ -9,7 +9,7 @@ import networkx as nx
 import pyproj
 from sklearn.neighbors import KDTree
 
-from src.space.utils import segmented
+from .utils import segmented
 
 
 class RoadNetwork:

--- a/gis/agents_and_networks/src/visualization/server.py
+++ b/gis/agents_and_networks/src/visualization/server.py
@@ -1,8 +1,8 @@
 import mesa
 
-from src.agent.building import Building
-from src.agent.commuter import Commuter
-from src.agent.geo_agents import Driveway, LakeAndRiver, Walkway
+from ..agent.building import Building
+from ..agent.commuter import Commuter
+from ..agent.geo_agents import Driveway, LakeAndRiver, Walkway
 
 
 class ClockElement(mesa.visualization.TextElement):

--- a/gis/geo_sir/model.py
+++ b/gis/geo_sir/model.py
@@ -1,7 +1,8 @@
 import mesa
 import mesa_geo as mg
-from agents import NeighbourhoodAgent, PersonAgent
 from shapely.geometry import Point
+
+from .agents import NeighbourhoodAgent, PersonAgent
 
 
 class GeoSir(mesa.Model):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,12 @@ license = {file = "LICENSE"}
 readme = "README.rst"
 requires-python = ">=3.8"
 
+[project.optional-dependencies]
+test = [""]
+test_gis = [
+  "momepy",
+]
+
 [build-system]
 requires = [
     "setuptools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,12 @@ readme = "README.rst"
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
-test = [""]
+test = [
+    "pytest",
+]
 test_gis = [
-  "momepy",
+    "pytest",
+    "momepy",
 ]
 
 [build-system]

--- a/test_gis_examples.py
+++ b/test_gis_examples.py
@@ -1,0 +1,34 @@
+import importlib
+import os
+
+import pytest
+from mesa import Model
+
+
+def get_models(directory):
+    models = []
+    for root, dirs, files in os.walk(directory):
+        for file in files:
+            if file == "model.py":
+                module_name = os.path.relpath(os.path.join(root, file[:-3])).replace(
+                    os.sep, "."
+                )
+
+                module = importlib.import_module(module_name)
+                for item in dir(module):
+                    obj = getattr(module, item)
+                    if (
+                        isinstance(obj, type)
+                        and issubclass(obj, Model)
+                        and obj is not Model
+                    ):
+                        models.append(obj)
+
+    return models
+
+
+@pytest.mark.parametrize("model_class", get_models("gis"))
+def test_model_steps(model_class):
+    model = model_class()  # Assume no arguments are needed
+    for _ in range(10):
+        model.step()


### PR DESCRIPTION
An effort to test all GIS models in CI.
 - [x] Use relative imports in all models. This way models can be ran from different locations, which will help with testing them.
 - [ ] Give al models default arguments
 - [x] Clean up and modernize current CI
 - [x] Define GIS dependencies as optional set in `pyproject.toml`
 - [x] Add CI configurations that runs on `.py` file changes in `gis` folder

PR is ready for review, all the CI and test code works as intended.

Some model example tests fail, and I will fix the most obvious ones, but all others can be fixed in separate PRs.

### Fix models TODO
- [ ] **GeoSchelling**
  - [ ] Fix missing file: `data/nuts_rg_60M_2013_lvl_2.geojson`

- [ ] **GeoSchellingPoints**
  - [ ] Fix missing file: `data/nuts_rg_60M_2013_lvl_2.geojson`

- [ ] **Rainfall**
  - [ ] Fix missing file: `/vsigzip/data/elevation.asc.gz`

- [ ] **Population**
  - [ ] Fix missing file: `/vsizip/data/clip.zip`

- [ ] **AgentsAndNetworks**
  - [ ] Provide the following required arguments:
    - [ ] `campus`
    - [ ] `data_crs`
    - [ ] `buildings_file`
    - [ ] `walkway_file`
    - [ ] `lakes_file`
    - [ ] `rivers_file`
    - [ ] `driveway_file`
    - [ ] `num_commuters`

- [ ] **GeoSir**
  - [ ] Fix missing file: `data/TorontoNeighbourhoods.geojson`

- [ ] **UrbanGrowth**
  - [ ] Provide missing argument for `RasterLayer.__init__()`: `model`