### PR TITLE
Add two missing `super().__init__()` to Mesa model initialization

### DIFF
--- a/gis/geo_schelling/model.py
+++ b/gis/geo_schelling/model.py
@@ -52,6 +52,7 @@ class GeoSchelling(mesa.Model):
     """Model class for the Schelling segregation model."""
 
     def __init__(self, density=0.6, minority_pc=0.2, export_data=False):
+        super().__init__()
         self.density = density
         self.minority_pc = minority_pc
         self.export_data = export_data

--- a/gis/geo_sir/model.py
+++ b/gis/geo_sir/model.py
@@ -24,6 +24,7 @@ class GeoSir(mesa.Model):
         :param infection_risk:      Probability of agent to become infected,
                                     if it has been exposed to another infected
         """
+        super().__init__()
         self.schedule = mesa.time.BaseScheduler(self)
         self.space = mg.GeoSpace(warn_crs_conversion=False)
         self.steps = 0


### PR DESCRIPTION
When inheriting from a Mesa Model you always need to initialize it by calling `super().__init__()`. This PR fixes that in two gis models: geo_schelling and geo_sir.

```Python
class MyModel(mesa.Model):
    def __init__(self):
        super().__init__()  # This is required!
```

Part of https://github.com/projectmesa/mesa-examples/issues/172.