### PR TITLE
Fix 3 data path imports in gis models

### DIFF
--- a/gis/geo_schelling/model.py
+++ b/gis/geo_schelling/model.py
@@ -1,7 +1,10 @@
+import os
 import random
 
 import mesa
 import mesa_geo as mg
+
+script_directory = os.path.dirname(os.path.abspath(__file__))
 
 
 class SchellingAgent(mg.GeoAgent):
@@ -67,7 +70,10 @@ class GeoSchelling(mesa.Model):
 
         # Set up the grid with patches for every NUTS region
         ac = mg.AgentCreator(SchellingAgent, model=self)
-        agents = ac.from_file("data/nuts_rg_60M_2013_lvl_2.geojson")
+        data_path = os.path.join(
+            script_directory, "data/nuts_rg_60M_2013_lvl_2.geojson"
+        )
+        agents = ac.from_file(filename=data_path)
         self.space.add_agents(agents)
 
         # Set up agents

--- a/gis/geo_schelling_points/geo_schelling_points/model.py
+++ b/gis/geo_schelling_points/geo_schelling_points/model.py
@@ -1,3 +1,4 @@
+import os
 import random
 import uuid
 
@@ -6,6 +7,8 @@ import mesa_geo as mg
 
 from .agents import PersonAgent, RegionAgent
 from .space import Nuts2Eu
+
+script_directory = os.path.dirname(os.path.abspath(__file__))
 
 
 class GeoSchellingPoints(mesa.Model):
@@ -24,9 +27,10 @@ class GeoSchellingPoints(mesa.Model):
 
         # Set up the grid with patches for every NUTS region
         ac = mg.AgentCreator(RegionAgent, model=self)
-        regions = ac.from_file(
-            "data/nuts_rg_60M_2013_lvl_2.geojson", unique_id="NUTS_ID"
+        data_path = os.path.join(
+            script_directory, "../data/nuts_rg_60M_2013_lvl_2.geojson"
         )
+        regions = ac.from_file(data_path, unique_id="NUTS_ID")
         self.space.add_regions(regions)
 
         for region in regions:

--- a/gis/geo_sir/model.py
+++ b/gis/geo_sir/model.py
@@ -1,15 +1,21 @@
+import os
+
 import mesa
 import mesa_geo as mg
 from shapely.geometry import Point
 
 from .agents import NeighbourhoodAgent, PersonAgent
 
+script_directory = os.path.dirname(os.path.abspath(__file__))
+
 
 class GeoSir(mesa.Model):
     """Model class for a simplistic infection model."""
 
     # Geographical parameters for desired map
-    geojson_regions = "data/TorontoNeighbourhoods.geojson"
+    geojson_regions = os.path.join(
+        script_directory, "data/TorontoNeighbourhoods.geojson"
+    )
     unique_id = "HOODNUM"
 
     def __init__(


### PR DESCRIPTION
Fix the data path import errors in the geo_schelling, geo_schelling_points and geo_sir models.

The problem was that many models are called from different place, and might be imported or not. The `os.path.dirname(os.path.abspath(__file__))` part gives the absolute path of the current file and then the directory it's in. From there we can robustly move to the location where the data is located, no matter if we're running locally or not.

Part of https://github.com/projectmesa/mesa-examples/issues/172.