### PR TITLE
Fix data paths and model passing in GIS examples

### DIFF
--- a/gis/geo_schelling/model.py
+++ b/gis/geo_schelling/model.py
@@ -1,10 +1,10 @@
-import os
 import random
+from pathlib import Path
 
 import mesa
 import mesa_geo as mg
 
-script_directory = os.path.dirname(os.path.abspath(__file__))
+script_directory = Path(__file__).resolve().parent
 
 
 class SchellingAgent(mg.GeoAgent):
@@ -70,9 +70,7 @@ class GeoSchelling(mesa.Model):
 
         # Set up the grid with patches for every NUTS region
         ac = mg.AgentCreator(SchellingAgent, model=self)
-        data_path = os.path.join(
-            script_directory, "data/nuts_rg_60M_2013_lvl_2.geojson"
-        )
+        data_path = script_directory / "data/nuts_rg_60M_2013_lvl_2.geojson"
         agents = ac.from_file(filename=data_path)
         self.space.add_agents(agents)
 

--- a/gis/geo_schelling_points/geo_schelling_points/model.py
+++ b/gis/geo_schelling_points/geo_schelling_points/model.py
@@ -1,6 +1,6 @@
-import os
 import random
 import uuid
+from pathlib import Path
 
 import mesa
 import mesa_geo as mg
@@ -8,7 +8,7 @@ import mesa_geo as mg
 from .agents import PersonAgent, RegionAgent
 from .space import Nuts2Eu
 
-script_directory = os.path.dirname(os.path.abspath(__file__))
+script_directory = Path(__file__).resolve().parent
 
 
 class GeoSchellingPoints(mesa.Model):
@@ -27,9 +27,7 @@ class GeoSchellingPoints(mesa.Model):
 
         # Set up the grid with patches for every NUTS region
         ac = mg.AgentCreator(RegionAgent, model=self)
-        data_path = os.path.join(
-            script_directory, "../data/nuts_rg_60M_2013_lvl_2.geojson"
-        )
+        data_path = script_directory / "../data/nuts_rg_60M_2013_lvl_2.geojson"
         regions = ac.from_file(data_path, unique_id="NUTS_ID")
         self.space.add_regions(regions)
 

--- a/gis/geo_sir/model.py
+++ b/gis/geo_sir/model.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import mesa
 import mesa_geo as mg
@@ -6,16 +6,14 @@ from shapely.geometry import Point
 
 from .agents import NeighbourhoodAgent, PersonAgent
 
-script_directory = os.path.dirname(os.path.abspath(__file__))
+script_directory = Path(__file__).resolve().parent
 
 
 class GeoSir(mesa.Model):
     """Model class for a simplistic infection model."""
 
     # Geographical parameters for desired map
-    geojson_regions = os.path.join(
-        script_directory, "data/TorontoNeighbourhoods.geojson"
-    )
+    geojson_regions = script_directory / "data/TorontoNeighbourhoods.geojson"
     unique_id = "HOODNUM"
 
     def __init__(

--- a/gis/population/population/model.py
+++ b/gis/population/population/model.py
@@ -1,3 +1,4 @@
+import os
 import math
 import random
 import uuid
@@ -8,6 +9,8 @@ import numpy as np
 from shapely.geometry import Point
 
 from .space import UgandaArea
+
+script_directory = os.path.dirname(os.path.abspath(__file__))
 
 
 class Person(mg.GeoAgent):
@@ -52,13 +55,18 @@ class Person(mg.GeoAgent):
 class Population(mesa.Model):
     def __init__(
         self,
-        population_gzip_file="data/popu.asc.gz",
-        lake_zip_file="data/lake.zip",
-        world_zip_file="data/clip.zip",
+        population_gzip_file="../data/popu.asc.gz",
+        lake_zip_file="../data/lake.zip",
+        world_zip_file="../data/clip.zip",
     ):
         super().__init__()
         self.space = UgandaArea(crs="epsg:4326")
-        self.space.load_data(population_gzip_file, lake_zip_file, world_zip_file)
+        self.space.load_data(
+            os.path.normpath(os.path.join(script_directory, population_gzip_file)),
+            os.path.join(script_directory, lake_zip_file),
+            os.path.join(script_directory, world_zip_file),
+            model=self,
+        )
         pixel_size_x, pixel_size_y = self.space.population_layer.resolution
         Person.MOBILITY_RANGE_X = pixel_size_x / 2.0
         Person.MOBILITY_RANGE_Y = pixel_size_y / 2.0

--- a/gis/population/population/model.py
+++ b/gis/population/population/model.py
@@ -1,7 +1,7 @@
 import math
-import os
 import random
 import uuid
+from pathlib import Path
 
 import mesa
 import mesa_geo as mg
@@ -10,7 +10,7 @@ from shapely.geometry import Point
 
 from .space import UgandaArea
 
-script_directory = os.path.dirname(os.path.abspath(__file__))
+script_directory = Path(__file__).resolve().parent
 
 
 class Person(mg.GeoAgent):
@@ -62,9 +62,9 @@ class Population(mesa.Model):
         super().__init__()
         self.space = UgandaArea(crs="epsg:4326")
         self.space.load_data(
-            os.path.normpath(os.path.join(script_directory, population_gzip_file)),
-            os.path.join(script_directory, lake_zip_file),
-            os.path.join(script_directory, world_zip_file),
+            script_directory / population_gzip_file,
+            script_directory / lake_zip_file,
+            script_directory / world_zip_file,
             model=self,
         )
         pixel_size_x, pixel_size_y = self.space.population_layer.resolution

--- a/gis/population/population/model.py
+++ b/gis/population/population/model.py
@@ -1,5 +1,5 @@
-import os
 import math
+import os
 import random
 import uuid
 

--- a/gis/population/population/space.py
+++ b/gis/population/population/space.py
@@ -32,7 +32,7 @@ class UgandaArea(GeoSpace):
     def __init__(self, crs):
         super().__init__(crs=crs)
 
-    def load_data(self, population_gzip_file, lake_zip_file, world_zip_file):
+    def load_data(self, population_gzip_file, lake_zip_file, world_zip_file, model):
         world_size = gpd.GeoDataFrame.from_file(world_zip_file)
         raster_layer = RasterLayer.from_file(
             f"/vsigzip/{population_gzip_file}",
@@ -43,7 +43,7 @@ class UgandaArea(GeoSpace):
         raster_layer.total_bounds = world_size.total_bounds
         self.add_layer(raster_layer)
         self.lake = gpd.GeoDataFrame.from_file(lake_zip_file).geometry[0]
-        self.add_agents(GeoAgent(uuid.uuid4().int, None, self.lake, self.crs))
+        self.add_agents(GeoAgent(uuid.uuid4().int, model, self.lake, self.crs))
 
     @property
     def population_layer(self):

--- a/gis/population/population/space.py
+++ b/gis/population/population/space.py
@@ -39,7 +39,6 @@ class UgandaArea(GeoSpace):
             f"/vsigzip/{population_gzip_file}",
             cell_cls=UgandaCell,
             attr_name="population",
-            model=model,
         )
         raster_layer.crs = world_size.crs
         raster_layer.total_bounds = world_size.total_bounds

--- a/gis/population/population/space.py
+++ b/gis/population/population/space.py
@@ -14,10 +14,11 @@ class UgandaCell(Cell):
 
     def __init__(
         self,
+        model,
         pos: mesa.space.Coordinate | None = None,
         indices: mesa.space.Coordinate | None = None,
     ):
-        super().__init__(pos, indices)
+        super().__init__(model, pos, indices)
         self.population = None
 
     def step(self):
@@ -38,6 +39,7 @@ class UgandaArea(GeoSpace):
             f"/vsigzip/{population_gzip_file}",
             cell_cls=UgandaCell,
             attr_name="population",
+            model=model,
         )
         raster_layer.crs = world_size.crs
         raster_layer.total_bounds = world_size.total_bounds

--- a/gis/rainfall/rainfall/model.py
+++ b/gis/rainfall/rainfall/model.py
@@ -66,7 +66,7 @@ class Rainfall(mesa.Model):
         self.export_data = export_data
         self.num_steps = num_steps
 
-        self.space = CraterLake(crs="epsg:4326", water_height=water_height)
+        self.space = CraterLake(crs="epsg:4326", water_height=water_height, model=self)
         self.schedule = mesa.time.RandomActivation(self)
         self.datacollector = mesa.DataCollector(
             {

--- a/gis/rainfall/rainfall/model.py
+++ b/gis/rainfall/rainfall/model.py
@@ -1,4 +1,5 @@
 import uuid
+import os
 
 import mesa
 import mesa_geo as mg
@@ -6,6 +7,8 @@ import numpy as np
 from shapely.geometry import Point
 
 from .space import CraterLake
+
+script_directory = os.path.dirname(os.path.abspath(__file__))
 
 
 class RaindropAgent(mg.GeoAgent):
@@ -73,7 +76,10 @@ class Rainfall(mesa.Model):
             }
         )
 
-        self.space.set_elevation_layer("data/elevation.asc.gz", crs="epsg:4326")
+        data_path = os.path.join(
+            script_directory, "../data/elevation.asc.gz"
+        )
+        self.space.set_elevation_layer(data_path, crs="epsg:4326")
 
     @property
     def contained(self):

--- a/gis/rainfall/rainfall/model.py
+++ b/gis/rainfall/rainfall/model.py
@@ -1,5 +1,5 @@
-import uuid
 import os
+import uuid
 
 import mesa
 import mesa_geo as mg

--- a/gis/rainfall/rainfall/model.py
+++ b/gis/rainfall/rainfall/model.py
@@ -1,5 +1,5 @@
-import os
 import uuid
+from pathlib import Path
 
 import mesa
 import mesa_geo as mg
@@ -8,7 +8,7 @@ from shapely.geometry import Point
 
 from .space import CraterLake
 
-script_directory = os.path.dirname(os.path.abspath(__file__))
+script_directory = Path(__file__).resolve().parent
 
 
 class RaindropAgent(mg.GeoAgent):
@@ -76,7 +76,7 @@ class Rainfall(mesa.Model):
             }
         )
 
-        data_path = os.path.join(script_directory, "../data/elevation.asc.gz")
+        data_path = script_directory / "../data/elevation.asc.gz"
         self.space.set_elevation_layer(data_path, crs="epsg:4326")
 
     @property

--- a/gis/rainfall/rainfall/model.py
+++ b/gis/rainfall/rainfall/model.py
@@ -76,9 +76,7 @@ class Rainfall(mesa.Model):
             }
         )
 
-        data_path = os.path.join(
-            script_directory, "../data/elevation.asc.gz"
-        )
+        data_path = os.path.join(script_directory, "../data/elevation.asc.gz")
         self.space.set_elevation_layer(data_path, crs="epsg:4326")
 
     @property

--- a/gis/rainfall/rainfall/space.py
+++ b/gis/rainfall/rainfall/space.py
@@ -37,7 +37,6 @@ class CraterLake(mg.GeoSpace):
             f"/vsigzip/{elevation_gzip_file}",
             cell_cls=LakeCell,
             attr_name="elevation",
-            model=self.model,
         )
         raster_layer.crs = crs
         raster_layer.apply_raster(

--- a/gis/rainfall/rainfall/space.py
+++ b/gis/rainfall/rainfall/space.py
@@ -12,10 +12,11 @@ class LakeCell(mg.Cell):
 
     def __init__(
         self,
+        model,
         pos: mesa.space.Coordinate | None = None,
         indices: mesa.space.Coordinate | None = None,
     ):
-        super().__init__(pos, indices)
+        super().__init__(model, pos, indices)
         self.elevation = None
         self.water_level = None
         self.water_level_normalized = None
@@ -25,14 +26,18 @@ class LakeCell(mg.Cell):
 
 
 class CraterLake(mg.GeoSpace):
-    def __init__(self, crs, water_height):
+    def __init__(self, crs, water_height, model):
         super().__init__(crs=crs)
+        self.model = model
         self.water_height = water_height
         self.outflow = 0
 
     def set_elevation_layer(self, elevation_gzip_file, crs):
         raster_layer = mg.RasterLayer.from_file(
-            f"/vsigzip/{elevation_gzip_file}", cell_cls=LakeCell, attr_name="elevation"
+            f"/vsigzip/{elevation_gzip_file}",
+            cell_cls=LakeCell,
+            attr_name="elevation",
+            model=self.model,
         )
         raster_layer.crs = crs
         raster_layer.apply_raster(

--- a/gis/urban_growth/urban_growth/model.py
+++ b/gis/urban_growth/urban_growth/model.py
@@ -64,6 +64,7 @@ class UrbanGrowth(mesa.Model):
             width=self.world_width,
             height=self.world_height,
             crs="epsg:3857",
+            model=self,
             total_bounds=[-901575.0, 1442925.0, -885645.0, 1454745.0],
         )
         self.space.load_datasets(

--- a/gis/urban_growth/urban_growth/model.py
+++ b/gis/urban_growth/urban_growth/model.py
@@ -1,11 +1,11 @@
-import os
+from pathlib import Path
 
 import mesa
 import numpy as np
 
 from .space import City
 
-script_directory = os.path.dirname(os.path.abspath(__file__))
+script_directory = Path(__file__).resolve().parent
 
 
 class UrbanGrowth(mesa.Model):
@@ -73,13 +73,9 @@ class UrbanGrowth(mesa.Model):
         )
 
         labels = ["urban", "slope", "road1", "excluded", "landuse"]
-        #     data_path = os.path.join(script_directory, f"data/{label}_santafe.asc.gz")
 
         self.space.load_datasets(
-            *(
-                os.path.join(script_directory, f"../data/{label}_santafe.asc.gz")
-                for label in labels
-            )
+            *(script_directory / f"../data/{label}_santafe.asc.gz" for label in labels)
         )
 
     def _check_suitability(self) -> None:

--- a/gis/urban_growth/urban_growth/model.py
+++ b/gis/urban_growth/urban_growth/model.py
@@ -75,7 +75,10 @@ class UrbanGrowth(mesa.Model):
         #     data_path = os.path.join(script_directory, f"data/{label}_santafe.asc.gz")
 
         self.space.load_datasets(
-            *(os.path.join(script_directory, f"../data/{label}_santafe.asc.gz") for label in labels)
+            *(
+                os.path.join(script_directory, f"../data/{label}_santafe.asc.gz")
+                for label in labels
+            )
         )
 
     def _check_suitability(self) -> None:

--- a/gis/urban_growth/urban_growth/model.py
+++ b/gis/urban_growth/urban_growth/model.py
@@ -1,6 +1,7 @@
+import os
+
 import mesa
 import numpy as np
-import os
 
 from .space import City
 

--- a/gis/urban_growth/urban_growth/model.py
+++ b/gis/urban_growth/urban_growth/model.py
@@ -1,7 +1,10 @@
 import mesa
 import numpy as np
+import os
 
 from .space import City
+
+script_directory = os.path.dirname(os.path.abspath(__file__))
 
 
 class UrbanGrowth(mesa.Model):
@@ -67,12 +70,12 @@ class UrbanGrowth(mesa.Model):
             model=self,
             total_bounds=[-901575.0, 1442925.0, -885645.0, 1454745.0],
         )
+
+        labels = ["urban", "slope", "road1", "excluded", "landuse"]
+        #     data_path = os.path.join(script_directory, f"data/{label}_santafe.asc.gz")
+
         self.space.load_datasets(
-            urban_data="data/urban_santafe.asc.gz",
-            slope_data="data/slope_santafe.asc.gz",
-            road_data="data/road1_santafe.asc.gz",
-            excluded_data="data/excluded_santafe.asc.gz",
-            land_use_data="data/landuse_santafe.asc.gz",
+            *(os.path.join(script_directory, f"../data/{label}_santafe.asc.gz") for label in labels)
         )
 
     def _check_suitability(self) -> None:

--- a/gis/urban_growth/urban_growth/space.py
+++ b/gis/urban_growth/urban_growth/space.py
@@ -26,10 +26,11 @@ class UrbanCell(mg.Cell):
 
     def __init__(
         self,
+        model: mesa.Model | None = None,
         pos: mesa.space.Coordinate | None = None,
         indices: mesa.space.Coordinate | None = None,
     ):
-        super().__init__(pos, indices)
+        super().__init__(model, pos, indices)
         self.urban = None
         self.slope = None
         self.road_1 = None

--- a/gis/urban_growth/urban_growth/space.py
+++ b/gis/urban_growth/urban_growth/space.py
@@ -78,10 +78,10 @@ class UrbanCell(mg.Cell):
 
 
 class City(mg.GeoSpace):
-    def __init__(self, width, height, crs, total_bounds):
+    def __init__(self, width, height, crs, total_bounds, model):
         super().__init__(crs=crs)
         self.add_layer(
-            mg.RasterLayer(width, height, crs, total_bounds, cell_cls=UrbanCell)
+            mg.RasterLayer(width, height, crs, total_bounds, model, cell_cls=UrbanCell)
         )
 
     def load_datasets(


### PR DESCRIPTION
This PR addresses several of the remaining issues across the GIS examples:

- Corrects data file paths in the population, rainfall, and urban growth models to use relative paths from the script directory.
- Fixes the urban growth model by passing the model object to City and UrbanCell classes, as required by mesa-geo 0.8.0.
- Updates the population model to pass the model object when creating agents, ensuring they can access Model variables and properties.
- Corrects the use of `/vsigzip/` paths for GDAL compatibility.

The `/vsigzip/` situation is super weird. It isn't part of the file path, but it's a "marker" a GDAL convention. See https://github.com/projectmesa/mesa-geo/issues/235 for more details. 

Part of #172.