### PR TITLE
Ensure grasspatches info is only collected if gras is true

### DIFF
--- a/examples/wolf_sheep/wolf_sheep/model.py
+++ b/examples/wolf_sheep/wolf_sheep/model.py
@@ -79,14 +79,16 @@ class WolfSheep(mesa.Model):
         self.sheep_gain_from_food = sheep_gain_from_food
 
         self.grid = mesa.space.MultiGrid(self.width, self.height, torus=True)
+
+
+        collectors = {"Wolves": lambda m: len(m.get_agents_of_type(Wolf)),
+                      "Sheep": lambda m: len(m.get_agents_of_type(Sheep))}
+
+        if grass:
+            collectors["Grass"] = lambda m: len(m.get_agents_of_type(GrassPatch))
+
         self.datacollector = mesa.DataCollector(
-            {
-                "Wolves": lambda m: len(m.get_agents_of_type(Wolf)),
-                "Sheep": lambda m: len(m.get_agents_of_type(Sheep)),
-                "Grass": lambda m: len(
-                    m.get_agents_of_type(GrassPatch).select(lambda a: a.fully_grown)
-                ),
-            }
+            collectors
         )
 
         # Create sheep:

--- a/examples/wolf_sheep/wolf_sheep/model.py
+++ b/examples/wolf_sheep/wolf_sheep/model.py
@@ -80,16 +80,15 @@ class WolfSheep(mesa.Model):
 
         self.grid = mesa.space.MultiGrid(self.width, self.height, torus=True)
 
-
-        collectors = {"Wolves": lambda m: len(m.get_agents_of_type(Wolf)),
-                      "Sheep": lambda m: len(m.get_agents_of_type(Sheep))}
+        collectors = {
+            "Wolves": lambda m: len(m.get_agents_of_type(Wolf)),
+            "Sheep": lambda m: len(m.get_agents_of_type(Sheep)),
+        }
 
         if grass:
             collectors["Grass"] = lambda m: len(m.get_agents_of_type(GrassPatch))
 
-        self.datacollector = mesa.DataCollector(
-            collectors
-        )
+        self.datacollector = mesa.DataCollector(collectors)
 
         # Create sheep:
         for i in range(self.initial_sheep):


### PR DESCRIPTION
the datacollector allways includes grasspatches even if grass is False. This is breaking (the proposed changes to agent storage in Model)[https://github.com/projectmesa/mesa/pull/2251#issue-2488519860].

The underlying problem is that `Model.get_agents_of_type` now raises a `KeyError` if type does not exist. I think this is desirable behavior becuase errrors should not be passed over in silence. But this requires fixing the wolf sheep example as done here. 