### PR TITLE
Add fast PropertyLayer implementation of Game of Life

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -42,7 +42,7 @@ jobs:
         pip install mesa --pre
         pip install .[test]
     - name: Test with pytest
-      run: pytest -rA -Werror test_examples.py
+      run: pytest -rA -Werror -Wdefault::FutureWarning test_examples.py
 
   build-main:
     runs-on: ubuntu-latest
@@ -57,4 +57,4 @@ jobs:
         pip install .[test]
         pip install -U git+https://github.com/projectmesa/mesa@main#egg=mesa
     - name: Test with pytest
-      run: pytest -rA -Werror test_examples.py
+      run: pytest -rA -Werror -Wdefault::FutureWarning test_examples.py

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ A cellular automaton model where agents opinions are influenced by that of their
 
 Implementation of [Conway's Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life), a cellular automata where simple rules can give rise to complex patterns.
 
+### [Conway's Game Of "Life" Model (Fast)](https://github.com/projectmesa/mesa-examples/tree/main/examples/conways_game_of_life_fast)
+
+A very fast performance optimized version of Conway's Game of Life using the Mesa [`PropertyLayer`](https://github.com/projectmesa/mesa/pull/1898). About 100x as fast as the regular versions, but limited visualisation (for [now](https://github.com/projectmesa/mesa/issues/2138)).
+
 ### [Conway's Game Of "Life" Model on a Hexagonal Grid](https://github.com/projectmesa/mesa-examples/tree/main/examples/hex_snowflake)
 
 Conway's game of life on a hexagonal grid.

--- a/examples/conways_game_of_life_fast/Readme.md
+++ b/examples/conways_game_of_life_fast/Readme.md
@@ -1,0 +1,54 @@
+## Conway's Game of Life (Fast)
+This example demonstrates a fast and efficient implementation of Conway's Game of Life using the [`PropertyLayer`](https://github.com/projectmesa/mesa/pull/1898) from the Mesa framework.
+
+### Overview
+Conway's [Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life) is a classic cellular automaton where each cell on a grid can either be alive or dead. The state of each cell changes over time based on a set of simple rules that depend on the number of alive neighbors.
+
+#### Key features:
+- **No grid or agents:** This implementation uses the `PropertyLayer` to manage the state of cells, eliminating the need for traditional grids or agents.
+- **Fast:** By using 2D convolution to count neighbors, the model efficiently applies the rules of the Game of Life across the entire grid.
+- **Toroidal:** The grid wraps around at the edges, creating a seamless, continuous surface.
+
+#### Performance
+The model is benchmarked in https://github.com/projectmesa/mesa/pull/1898#issuecomment-1849000346 to be about 100x faster over a traditional implementation.
+
+![runtime_comparison](https://github.com/projectmesa/mesa/assets/15776622/d30232c6-e23b-499b-8698-14695a95e627)
+
+- Benchmark code: [benchmark_gol.zip](https://github.com/projectmesa/mesa/files/13628343/benchmark_gol.zip)
+
+### Getting Started
+#### Prerequisites
+- Python 3.9 or higher
+- Mesa 2.3 or higher
+- NumPy and SciPy
+
+#### Running the Model
+To run the model, open a new file or notebook and add:
+
+```Python
+from model import GameOfLifeModel
+model = GameOfLifeModel(width=10, height=10, alive_fraction=0.2)
+for i in range(10):
+    model.step()
+```
+Or to run visualized with Solara, run in your terminal:
+
+```bash
+solara run app.py
+```
+
+### Understanding the Code
+- **Model initialization:** The grid is represented by a `PropertyLayer` where each cell is randomly initialized as alive or dead based on a given probability.
+- **`PropertyLayer`:** In the `cell_layer` (which is a `PropertyLayer`), each cell has either a value of 1 (alive) or 0 (dead).
+- **Step function:** Each simulation step calculates the number of alive neighbors for each cell and applies the Game of Life rules.
+- **Data collection:** The model tracks and reports the number of alive cells and the fraction of the grid that is alive.
+
+### Customization
+You can easily modify the model parameters such as grid size and initial alive fraction to explore different scenarios. You can also add more metrics or visualisations.
+
+### Summary
+This example provides a fast approach to modeling cellular automata using Mesa's `PropertyLayer`.
+
+### Future work
+Add visualisation of the `PropertyLayer` in SolaraViz. See:
+- https://github.com/projectmesa/mesa/issues/2138

--- a/examples/conways_game_of_life_fast/app.py
+++ b/examples/conways_game_of_life_fast/app.py
@@ -23,6 +23,7 @@ model_params = {
 page = SolaraViz(
     GameOfLifeModel,
     model_params,
+    measures=["Cells alive", "Fraction alive"],
     space_drawer=None,
     name="Game of Life Model",
 )

--- a/examples/conways_game_of_life_fast/app.py
+++ b/examples/conways_game_of_life_fast/app.py
@@ -1,0 +1,29 @@
+from mesa.visualization import SolaraViz
+from model import GameOfLifeModel
+
+model_params = {
+    "width": {
+        "type": "SliderInt",
+        "value": 10,
+        "label": "Width",
+        "min": 5,
+        "max": 25,
+        "step": 1,
+    },
+    "height": {
+        "type": "SliderInt",
+        "value": 10,
+        "label": "Height",
+        "min": 5,
+        "max": 25,
+        "step": 1,
+    },
+}
+
+page = SolaraViz(
+    GameOfLifeModel,
+    model_params,
+    space_drawer=None,
+    name="Game of Life Model",
+)
+page  # noqa

--- a/examples/conways_game_of_life_fast/model.py
+++ b/examples/conways_game_of_life_fast/model.py
@@ -24,7 +24,6 @@ class GameOfLifeModel(Model):
         self.datacollector.collect(self)
 
     def step(self):
-        self._advance_time()
         # Define a kernel for counting neighbors. The kernel has 1s around the center cell (which is 0).
         # This setup allows us to count the live neighbors of each cell when we apply convolution.
         kernel = np.array([[1, 1, 1],

--- a/examples/conways_game_of_life_fast/model.py
+++ b/examples/conways_game_of_life_fast/model.py
@@ -1,0 +1,36 @@
+import numpy as np
+from mesa import Model
+from mesa.space import PropertyLayer
+from scipy.signal import convolve2d
+
+# fmt: off
+class GameOfLifeModel(Model):
+    def __init__(self, width=10, height=10, alive_fraction=0.2):
+        super().__init__()
+        # Initialize the property layer for cell states
+        self.cell_layer = PropertyLayer("cells", width, height, False, dtype=bool)
+        # Randomly set cells to alive
+        self.cell_layer.data = np.random.choice([True, False], size=(width, height), p=[alive_fraction, 1 - alive_fraction])
+
+    def step(self):
+        self._advance_time()
+        # Define a kernel for counting neighbors. The kernel has 1s around the center cell (which is 0).
+        # This setup allows us to count the live neighbors of each cell when we apply convolution.
+        kernel = np.array([[1, 1, 1],
+                           [1, 0, 1],
+                           [1, 1, 1]])
+
+        # Count neighbors using convolution.
+        # convolve2d applies the kernel to each cell of the grid, summing up the values of neighbors.
+        # boundary="wrap" ensures that the grid wraps around, simulating a toroidal surface.
+        neighbor_count = convolve2d(self.cell_layer.data, kernel, mode="same", boundary="wrap")
+
+        # Apply Game of Life rules:
+        # 1. A live cell with 2 or 3 live neighbors survives, otherwise it dies.
+        # 2. A dead cell with exactly 3 live neighbors becomes alive.
+        # These rules are implemented using logical operations on the grid.
+        self.cell_layer.data = np.logical_or(
+            np.logical_and(self.cell_layer.data, np.logical_or(neighbor_count == 2, neighbor_count == 3)),
+            # Rule for live cells
+            np.logical_and(~self.cell_layer.data, neighbor_count == 3)  # Rule for dead cells
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.8"
 [project.optional-dependencies]
 test = [
     "pytest",
+    "scipy",
 ]
 test_gis = [
     "pytest",


### PR DESCRIPTION
This pull request adds a fast implementation of Conway's Game of Life using the `PropertyLayer`. Unlike traditional approaches, this version doesn't rely on a grid or agents, making it simpler and more efficient (in this specific case).

### Key features
- The model uses a `PropertyLayer` to track cell states, removing the need for a grid or agents. In this layer, a cell value of 1 means being alive, and 0 means being dead.
- Neighbor counts are calculated using 2D convolution, which speeds up the process of applying the Game of Life rules.
- The model wraps the grid edges to create a continuous surface, so cells on the edges behave as if the grid is infinite.
- The model tracks and records the number of living cells and the percentage of the grid that's alive over time.

### Performance
As benchmarked in https://github.com/projectmesa/mesa/pull/1898#issuecomment-1849000346, this models is incredibly fast, about 100x over a traditional implementation.

![runtime_comparison](https://github.com/projectmesa/mesa/assets/15776622/d30232c6-e23b-499b-8698-14695a95e627)

- Benchmark code: [benchmark_gol.zip](https://github.com/projectmesa/mesa/files/13628343/benchmark_gol.zip)

### Structure
This PR is structures in three commits:
- 556afd8 adds the base model
- bd854d8 adds a minimal Solara visualisation
- d9ae175 adds metrics, a datacollector and visualizes these metrics in Solara
- 5ab4720 adds a Readme
- af7309c adds SciPy to the example test dependencies
- 0a36938 allows a FutureWarning to stay a warning and not become an Error 

### Dependencies
This models needs SciPy for `convolve2d`, which is added to the test dependencies.

### Future work
It would be nice if the PropertyLayer itself could also be visualized, so that you can see Game of Life patterns. That needs support in Mesa however (or a custom `space_drawer` implemented here).
- https://github.com/projectmesa/mesa/issues/2138

Closes: #166