### PR TITLE
Reinstate PR #161: Replace schedulers with AgentSet functionality

### DIFF
--- a/examples/bank_reserves/bank_reserves/agents.py
+++ b/examples/bank_reserves/bank_reserves/agents.py
@@ -10,15 +10,18 @@ Author of NetLogo code:
     Northwestern University, Evanston, IL.
 """
 
-import mesa
-
 from .random_walk import RandomWalker
 
 
-class Bank(mesa.Agent):
-    def __init__(self, unique_id, model, reserve_percent=50):
-        # initialize the parent class with required parameters
-        super().__init__(unique_id, model)
+class Bank:
+    """Note that the Bank class is not a Mesa Agent, but just a regular Python
+    class. This is because there is only one bank in this model, and it does not
+    use any Mesa-specific features like the scheduler or the grid, and doesn't
+    have a step method. It is just used to keep track of the bank's reserves and
+    the amount it can loan out, for Person agents to interact with."""
+
+    def __init__(self, model, reserve_percent=50):
+        self.model = model
         # for tracking total value of loans outstanding
         self.bank_loans = 0
         """percent of deposits the bank must keep in reserves - this is set via
@@ -173,7 +176,6 @@ class Person(RandomWalker):
         # increase the bank's outstanding loans
         self.bank.bank_loans += amount
 
-    # step is called for each agent in model.BankReservesModel.schedule.step()
     def step(self):
         # move to a cell in my Moore neighborhood
         self.random_move()

--- a/examples/bank_reserves/bank_reserves/model.py
+++ b/examples/bank_reserves/bank_reserves/model.py
@@ -26,14 +26,14 @@ For details see batch_run.py in the same directory as run.py.
 def get_num_rich_agents(model):
     """return number of rich agents"""
 
-    rich_agents = [a for a in model.schedule.agents if a.savings > model.rich_threshold]
+    rich_agents = [a for a in model.agents if a.savings > model.rich_threshold]
     return len(rich_agents)
 
 
 def get_num_poor_agents(model):
     """return number of poor agents"""
 
-    poor_agents = [a for a in model.schedule.agents if a.loans > 10]
+    poor_agents = [a for a in model.agents if a.loans > 10]
     return len(poor_agents)
 
 
@@ -41,9 +41,7 @@ def get_num_mid_agents(model):
     """return number of middle class agents"""
 
     mid_agents = [
-        a
-        for a in model.schedule.agents
-        if a.loans < 10 and a.savings < model.rich_threshold
+        a for a in model.agents if a.loans < 10 and a.savings < model.rich_threshold
     ]
     return len(mid_agents)
 
@@ -51,7 +49,7 @@ def get_num_mid_agents(model):
 def get_total_savings(model):
     """sum of all agents' savings"""
 
-    agent_savings = [a.savings for a in model.schedule.agents]
+    agent_savings = [a.savings for a in model.agents]
     # return the sum of agents' savings
     return np.sum(agent_savings)
 
@@ -59,7 +57,7 @@ def get_total_savings(model):
 def get_total_wallets(model):
     """sum of amounts of all agents' wallets"""
 
-    agent_wallets = [a.wallet for a in model.schedule.agents]
+    agent_wallets = [a.wallet for a in model.agents]
     # return the sum of all agents' wallets
     return np.sum(agent_wallets)
 
@@ -75,7 +73,7 @@ def get_total_money(model):
 
 def get_total_loans(model):
     # list of amounts of all agents' loans
-    agent_loans = [a.loans for a in model.schedule.agents]
+    agent_loans = [a.loans for a in model.agents]
     # return sum of all agents' loans
     return np.sum(agent_loans)
 
@@ -118,7 +116,7 @@ class BankReserves(mesa.Model):
         self.height = height
         self.width = width
         self.init_people = init_people
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.grid = mesa.space.MultiGrid(self.width, self.height, torus=True)
         # rich_threshold is the amount of savings a person needs to be considered "rich"
         self.rich_threshold = rich_threshold
@@ -138,7 +136,7 @@ class BankReserves(mesa.Model):
         )
 
         # create a single bank for the model
-        self.bank = Bank(1, self, self.reserve_percent)
+        self.bank = Bank(self, self.reserve_percent)
 
         # create people for the model according to number of people set by user
         for i in range(self.init_people):
@@ -148,15 +146,13 @@ class BankReserves(mesa.Model):
             p = Person(i, self, True, self.bank, self.rich_threshold)
             # place the Person object on the grid at coordinates (x, y)
             self.grid.place_agent(p, (x, y))
-            # add the Person object to the model schedule
-            self.schedule.add(p)
 
         self.running = True
         self.datacollector.collect(self)
 
     def step(self):
         # tell all the agents in the model to run their step function
-        self.schedule.step()
+        self.agents.shuffle().do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/bank_reserves/batch_run.py
+++ b/examples/bank_reserves/batch_run.py
@@ -37,7 +37,7 @@ from bank_reserves.agents import Bank, Person
 def get_num_rich_agents(model):
     """list of rich agents"""
 
-    rich_agents = [a for a in model.schedule.agents if a.savings > model.rich_threshold]
+    rich_agents = [a for a in model.agents if a.savings > model.rich_threshold]
     # return number of rich agents
     return len(rich_agents)
 
@@ -45,7 +45,7 @@ def get_num_rich_agents(model):
 def get_num_poor_agents(model):
     """list of poor agents"""
 
-    poor_agents = [a for a in model.schedule.agents if a.loans > 10]
+    poor_agents = [a for a in model.agents if a.loans > 10]
     # return number of poor agents
     return len(poor_agents)
 
@@ -54,9 +54,7 @@ def get_num_mid_agents(model):
     """list of middle class agents"""
 
     mid_agents = [
-        a
-        for a in model.schedule.agents
-        if a.loans < 10 and a.savings < model.rich_threshold
+        a for a in model.agents if a.loans < 10 and a.savings < model.rich_threshold
     ]
     # return number of middle class agents
     return len(mid_agents)
@@ -65,7 +63,7 @@ def get_num_mid_agents(model):
 def get_total_savings(model):
     """list of amounts of all agents' savings"""
 
-    agent_savings = [a.savings for a in model.schedule.agents]
+    agent_savings = [a.savings for a in model.agents]
     # return the sum of agents' savings
     return np.sum(agent_savings)
 
@@ -73,7 +71,7 @@ def get_total_savings(model):
 def get_total_wallets(model):
     """list of amounts of all agents' wallets"""
 
-    agent_wallets = [a.wallet for a in model.schedule.agents]
+    agent_wallets = [a.wallet for a in model.agents]
     # return the sum of all agents' wallets
     return np.sum(agent_wallets)
 
@@ -91,7 +89,7 @@ def get_total_money(model):
 def get_total_loans(model):
     """list of amounts of all agents' loans"""
 
-    agent_loans = [a.loans for a in model.schedule.agents]
+    agent_loans = [a.loans for a in model.agents]
     # return sum of all agents' loans
     return np.sum(agent_loans)
 
@@ -129,7 +127,7 @@ class BankReservesModel(mesa.Model):
         self.height = height
         self.width = width
         self.init_people = init_people
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.grid = mesa.space.MultiGrid(self.width, self.height, torus=True)
         # rich_threshold is the amount of savings a person needs to be considered "rich"
         self.rich_threshold = rich_threshold
@@ -150,8 +148,8 @@ class BankReservesModel(mesa.Model):
             agent_reporters={"Wealth": "wealth"},
         )
 
-        # create a single bank for the model
-        self.bank = Bank(1, self, self.reserve_percent)
+        # create a single bank object for the model
+        self.bank = Bank(self, self.reserve_percent)
 
         # create people for the model according to number of people set by user
         for i in range(self.init_people):
@@ -162,8 +160,6 @@ class BankReservesModel(mesa.Model):
             p = Person(i, (x, y), self, True, self.bank, self.rich_threshold)
             # place the Person object on the grid at coordinates (x, y)
             self.grid.place_agent(p, (x, y))
-            # add the Person object to the model schedule
-            self.schedule.add(p)
 
         self.running = True
 
@@ -171,7 +167,7 @@ class BankReservesModel(mesa.Model):
         # collect data
         self.datacollector.collect(self)
         # tell all the agents in the model to run their step function
-        self.schedule.step()
+        self.agents.shuffle().do("step")
 
     def run_model(self):
         for i in range(self.run_time):

--- a/examples/boid_flockers/Flocker Test.ipynb
+++ b/examples/boid_flockers/Flocker Test.ipynb
@@ -25,7 +25,7 @@
     "def draw_boids(model):\n",
     "    x_vals = []\n",
     "    y_vals = []\n",
-    "    for boid in model.schedule.agents:\n",
+    "    for boid in model.agents:\n",
     "        x, y = boid.pos\n",
     "        x_vals.append(x)\n",
     "        y_vals.append(y)\n",

--- a/examples/boid_flockers/boid_flockers/SimpleContinuousModule.py
+++ b/examples/boid_flockers/boid_flockers/SimpleContinuousModule.py
@@ -18,7 +18,7 @@ class SimpleCanvas(mesa.visualization.VisualizationElement):
 
     def render(self, model):
         space_state = []
-        for obj in model.schedule.agents:
+        for obj in model.agents:
             portrayal = self.portrayal_method(obj)
             x, y = obj.pos
             x = (x - model.space.x_min) / (model.space.x_max - model.space.x_min)

--- a/examples/boid_flockers/boid_flockers/model.py
+++ b/examples/boid_flockers/boid_flockers/model.py
@@ -120,7 +120,7 @@ class BoidFlockers(mesa.Model):
         self.vision = vision
         self.speed = speed
         self.separation = separation
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.space = mesa.space.ContinuousSpace(width, height, True)
         self.factors = {"cohere": cohere, "separate": separate, "match": match}
         self.make_agents()
@@ -144,7 +144,6 @@ class BoidFlockers(mesa.Model):
                 **self.factors,
             )
             self.space.place_agent(boid, pos)
-            self.schedule.add(boid)
 
     def step(self):
-        self.schedule.step()
+        self.agents.shuffle().do("step")

--- a/examples/boltzmann_wealth_model/boltzmann_wealth_model/model.py
+++ b/examples/boltzmann_wealth_model/boltzmann_wealth_model/model.py
@@ -2,7 +2,7 @@ import mesa
 
 
 def compute_gini(model):
-    agent_wealths = [agent.wealth for agent in model.schedule.agents]
+    agent_wealths = [agent.wealth for agent in model.agents]
     x = sorted(agent_wealths)
     N = model.num_agents
     B = sum(xi * (N - i) for i, xi in enumerate(x)) / (N * sum(x))
@@ -21,14 +21,14 @@ class BoltzmannWealthModel(mesa.Model):
         super().__init__()
         self.num_agents = N
         self.grid = mesa.space.MultiGrid(width, height, True)
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.datacollector = mesa.DataCollector(
             model_reporters={"Gini": compute_gini}, agent_reporters={"Wealth": "wealth"}
         )
         # Create agents
         for i in range(self.num_agents):
             a = MoneyAgent(i, self)
-            self.schedule.add(a)
+
             # Add the agent to a random grid cell
             x = self.random.randrange(self.grid.width)
             y = self.random.randrange(self.grid.height)
@@ -38,7 +38,7 @@ class BoltzmannWealthModel(mesa.Model):
         self.datacollector.collect(self)
 
     def step(self):
-        self.schedule.step()
+        self.agents.shuffle().do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/boltzmann_wealth_model_experimental/model.py
+++ b/examples/boltzmann_wealth_model_experimental/model.py
@@ -2,7 +2,7 @@ import mesa
 
 
 def compute_gini(model):
-    agent_wealths = [agent.wealth for agent in model.schedule.agents]
+    agent_wealths = [agent.wealth for agent in model.agents]
     x = sorted(agent_wealths)
     N = model.num_agents
     B = sum(xi * (N - i) for i, xi in enumerate(x)) / (N * sum(x))
@@ -21,14 +21,14 @@ class BoltzmannWealthModel(mesa.Model):
         super().__init__()
         self.num_agents = N
         self.grid = mesa.space.MultiGrid(width, height, True)
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.datacollector = mesa.DataCollector(
             model_reporters={"Gini": compute_gini}, agent_reporters={"Wealth": "wealth"}
         )
         # Create agents
         for i in range(self.num_agents):
             a = MoneyAgent(i, self)
-            self.schedule.add(a)
+
             # Add the agent to a random grid cell
             x = self.random.randrange(self.grid.width)
             y = self.random.randrange(self.grid.height)
@@ -38,7 +38,7 @@ class BoltzmannWealthModel(mesa.Model):
         self.datacollector.collect(self)
 
     def step(self):
-        self.schedule.step()
+        self.agents.shuffle().do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
+++ b/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
@@ -3,7 +3,7 @@ import networkx as nx
 
 
 def compute_gini(model):
-    agent_wealths = [agent.wealth for agent in model.schedule.agents]
+    agent_wealths = [agent.wealth for agent in model.agents]
     x = sorted(agent_wealths)
     N = model.num_agents
     B = sum(xi * (N - i) for i, xi in enumerate(x)) / (N * sum(x))
@@ -19,7 +19,7 @@ class BoltzmannWealthModelNetwork(mesa.Model):
         self.num_nodes = num_nodes if num_nodes >= self.num_agents else self.num_agents
         self.G = nx.erdos_renyi_graph(n=self.num_nodes, p=0.5)
         self.grid = mesa.space.NetworkGrid(self.G)
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.datacollector = mesa.DataCollector(
             model_reporters={"Gini": compute_gini},
             agent_reporters={"Wealth": lambda _: _.wealth},
@@ -30,7 +30,7 @@ class BoltzmannWealthModelNetwork(mesa.Model):
         # Create agents
         for i in range(self.num_agents):
             a = MoneyAgent(i, self)
-            self.schedule.add(a)
+
             # Add the agent to a random node
             self.grid.place_agent(a, list_of_random_nodes[i])
 
@@ -38,7 +38,7 @@ class BoltzmannWealthModelNetwork(mesa.Model):
         self.datacollector.collect(self)
 
     def step(self):
-        self.schedule.step()
+        self.agents.shuffle().do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/caching_and_replay/model.py
+++ b/examples/caching_and_replay/model.py
@@ -70,7 +70,6 @@ class Schelling(mesa.Model):
         self.homophily = homophily
         self.radius = radius
 
-        self.schedule = mesa.time.RandomActivation(self)
         self.grid = mesa.space.SingleGrid(width, height, torus=True)
 
         self.happy = 0
@@ -87,7 +86,6 @@ class Schelling(mesa.Model):
                 agent_type = 1 if self.random.random() < self.minority_pc else 0
                 agent = SchellingAgent(self.next_id(), self, agent_type)
                 self.grid.place_agent(agent, pos)
-                self.schedule.add(agent)
 
         self.datacollector.collect(self)
 
@@ -96,9 +94,9 @@ class Schelling(mesa.Model):
         Run one step of the model.
         """
         self.happy = 0  # Reset counter of happy agents
-        self.schedule.step()
+        self.agents.shuffle().do("step")
 
         self.datacollector.collect(self)
 
-        if self.happy == self.schedule.get_agent_count():
+        if self.happy == len(self.agents):
             self.running = False

--- a/examples/charts/charts/agents.py
+++ b/examples/charts/charts/agents.py
@@ -10,15 +10,18 @@ Author of NetLogo code:
     Northwestern University, Evanston, IL.
 """
 
-import mesa
-
 from .random_walk import RandomWalker
 
 
-class Bank(mesa.Agent):
-    def __init__(self, unique_id, model, reserve_percent=50):
-        # initialize the parent class with required parameters
-        super().__init__(unique_id, model)
+class Bank:
+    """Note that the Bank class is not a Mesa Agent, but just a regular Python
+    class. This is because there is only one bank in this model, and it does not
+    use any Mesa-specific features like the scheduler or the grid, and doesn't
+    have a step method. It is just used to keep track of the bank's reserves and
+    the amount it can loan out, for Person agents to interact with."""
+
+    def __init__(self, model, reserve_percent=50):
+        self.model = model
         # for tracking total value of loans outstanding
         self.bank_loans = 0
         """percent of deposits the bank must keep in reserves - this is set via
@@ -173,7 +176,6 @@ class Person(RandomWalker):
         # increase the bank's outstanding loans
         self.bank.bank_loans += amount
 
-    # step is called for each agent in model.BankReservesModel.schedule.step()
     def step(self):
         # move to a cell in my Moore neighborhood
         self.random_move()

--- a/examples/charts/charts/model.py
+++ b/examples/charts/charts/model.py
@@ -26,14 +26,14 @@ For details see batch_run.py in the same directory as run.py.
 def get_num_rich_agents(model):
     """return number of rich agents"""
 
-    rich_agents = [a for a in model.schedule.agents if a.savings > model.rich_threshold]
+    rich_agents = [a for a in model.agents if a.savings > model.rich_threshold]
     return len(rich_agents)
 
 
 def get_num_poor_agents(model):
     """return number of poor agents"""
 
-    poor_agents = [a for a in model.schedule.agents if a.loans > 10]
+    poor_agents = [a for a in model.agents if a.loans > 10]
     return len(poor_agents)
 
 
@@ -41,9 +41,7 @@ def get_num_mid_agents(model):
     """return number of middle class agents"""
 
     mid_agents = [
-        a
-        for a in model.schedule.agents
-        if a.loans < 10 and a.savings < model.rich_threshold
+        a for a in model.agents if a.loans < 10 and a.savings < model.rich_threshold
     ]
     return len(mid_agents)
 
@@ -51,7 +49,7 @@ def get_num_mid_agents(model):
 def get_total_savings(model):
     """sum of all agents' savings"""
 
-    agent_savings = [a.savings for a in model.schedule.agents]
+    agent_savings = [a.savings for a in model.agents]
     # return the sum of agents' savings
     return np.sum(agent_savings)
 
@@ -59,7 +57,7 @@ def get_total_savings(model):
 def get_total_wallets(model):
     """sum of amounts of all agents' wallets"""
 
-    agent_wallets = [a.wallet for a in model.schedule.agents]
+    agent_wallets = [a.wallet for a in model.agents]
     # return the sum of all agents' wallets
     return np.sum(agent_wallets)
 
@@ -75,7 +73,7 @@ def get_total_money(model):
 
 def get_total_loans(model):
     # list of amounts of all agents' loans
-    agent_loans = [a.loans for a in model.schedule.agents]
+    agent_loans = [a.loans for a in model.agents]
     # return sum of all agents' loans
     return np.sum(agent_loans)
 
@@ -101,7 +99,7 @@ class Charts(mesa.Model):
         self.height = height
         self.width = width
         self.init_people = init_people
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.grid = mesa.space.MultiGrid(self.width, self.height, torus=True)
         # rich_threshold is the amount of savings a person needs to be considered "rich"
         self.rich_threshold = rich_threshold
@@ -121,7 +119,7 @@ class Charts(mesa.Model):
         )
 
         # create a single bank for the model
-        self.bank = Bank(1, self, self.reserve_percent)
+        self.bank = Bank(self, self.reserve_percent)
 
         # create people for the model according to number of people set by user
         for i in range(self.init_people):
@@ -131,15 +129,13 @@ class Charts(mesa.Model):
             p = Person(i, self, True, self.bank, self.rich_threshold)
             # place the Person object on the grid at coordinates (x, y)
             self.grid.place_agent(p, (x, y))
-            # add the Person object to the model schedule
-            self.schedule.add(p)
 
         self.running = True
         self.datacollector.collect(self)
 
     def step(self):
         # tell all the agents in the model to run their step function
-        self.schedule.step()
+        self.agents.shuffle().do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/conways_game_of_life/conways_game_of_life/cell.py
+++ b/examples/conways_game_of_life/conways_game_of_life/cell.py
@@ -24,7 +24,7 @@ class Cell(mesa.Agent):
     def neighbors(self):
         return self.model.grid.iter_neighbors((self.x, self.y), True)
 
-    def step(self):
+    def determine_state(self):
         """
         Compute if the cell will be dead or alive at the next tick.  This is
         based on the number of alive or dead neighbors.  The state is not
@@ -46,7 +46,7 @@ class Cell(mesa.Agent):
             if live_neighbors == 3:
                 self._nextState = self.ALIVE
 
-    def advance(self):
+    def assume_state(self):
         """
         Set the state to the new computed state -- computed in step().
         """

--- a/examples/conways_game_of_life/conways_game_of_life/model.py
+++ b/examples/conways_game_of_life/conways_game_of_life/model.py
@@ -14,15 +14,6 @@ class ConwaysGameOfLife(mesa.Model):
         Create a new playing area of (width, height) cells.
         """
         super().__init__()
-
-        # Set up the grid and schedule.
-
-        # Use SimultaneousActivation which simulates all the cells
-        # computing their next state simultaneously.  This needs to
-        # be done because each cell's next state depends on the current
-        # state of all its neighbors -- before they've changed.
-        self.schedule = mesa.time.SimultaneousActivation(self)
-
         # Use a simple grid, where edges wrap around.
         self.grid = mesa.space.SingleGrid(width, height, torus=True)
 
@@ -33,12 +24,14 @@ class ConwaysGameOfLife(mesa.Model):
             if self.random.random() < 0.1:
                 cell.state = cell.ALIVE
             self.grid.place_agent(cell, (x, y))
-            self.schedule.add(cell)
 
         self.running = True
 
     def step(self):
         """
-        Have the scheduler advance each cell by one step
+        Perform the model step in two stages:
+        - First, all cells assume their next state (whether they will be dead or alive)
+        - Then, all cells change state to their next state
         """
-        self.schedule.step()
+        self.agents.do("determine_state")
+        self.agents.do("assume_state")

--- a/examples/el_farol/el_farol/agents.py
+++ b/examples/el_farol/el_farol/agents.py
@@ -14,7 +14,7 @@ class BarCustomer(mesa.Agent):
         self.utility = 0
         self.update_strategies()
 
-    def step(self):
+    def update_attendance(self):
         prediction = self.predict_attendance(
             self.best_strategy, self.model.history[-self.memory_size :]
         )

--- a/examples/el_farol/el_farol/model.py
+++ b/examples/el_farol/el_farol/model.py
@@ -15,7 +15,6 @@ class ElFarolBar(mesa.Model):
         super().__init__()
         self.running = True
         self.num_agents = N
-        self.schedule = mesa.time.RandomActivation(self)
 
         # Initialize the previous attendance randomly so the agents have a history
         # to work with from the start.
@@ -25,8 +24,8 @@ class ElFarolBar(mesa.Model):
         self.history = np.random.randint(0, 100, size=memory_size * 2).tolist()
         self.attendance = self.history[-1]
         for i in range(self.num_agents):
-            a = BarCustomer(i, self, memory_size, crowd_threshold, num_strategies)
-            self.schedule.add(a)
+            BarCustomer(i, self, memory_size, crowd_threshold, num_strategies)
+
         self.datacollector = mesa.DataCollector(
             model_reporters={"Customers": "attendance"},
             agent_reporters={"Utility": "utility", "Attendance": "attend"},
@@ -35,10 +34,9 @@ class ElFarolBar(mesa.Model):
     def step(self):
         self.datacollector.collect(self)
         self.attendance = 0
-        self.schedule.step()
+        self.agents.shuffle().do("update_attendance")
         # We ensure that the length of history is constant
         # after each step.
         self.history.pop(0)
         self.history.append(self.attendance)
-        for agent in self.schedule.agents:
-            agent.update_strategies()
+        self.agents.shuffle().do("update_strategies")

--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -58,7 +58,7 @@ class EpsteinCivilViolence(mesa.Model):
         self.movement = movement
         self.max_iters = max_iters
         self.iteration = 0
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.grid = mesa.space.SingleGrid(width, height, torus=True)
 
         model_reporters = {
@@ -86,7 +86,7 @@ class EpsteinCivilViolence(mesa.Model):
                 cop = Cop(unique_id, self, (x, y), vision=self.cop_vision)
                 unique_id += 1
                 self.grid[x][y] = cop
-                self.schedule.add(cop)
+
             elif self.random.random() < (self.cop_density + self.citizen_density):
                 citizen = Citizen(
                     unique_id,
@@ -100,7 +100,6 @@ class EpsteinCivilViolence(mesa.Model):
                 )
                 unique_id += 1
                 self.grid[x][y] = citizen
-                self.schedule.add(citizen)
 
         self.running = True
         self.datacollector.collect(self)
@@ -109,7 +108,7 @@ class EpsteinCivilViolence(mesa.Model):
         """
         Advance the model by one step and collect data.
         """
-        self.schedule.step()
+        self.agents.shuffle().do("step")
         # collect data
         self.datacollector.collect(self)
         self.iteration += 1
@@ -122,7 +121,7 @@ class EpsteinCivilViolence(mesa.Model):
         Helper method to count agents by Quiescent/Active.
         """
         count = 0
-        for agent in model.schedule.agents:
+        for agent in model.agents:
             if agent.breed == "cop":
                 continue
             if exclude_jailed and agent.jail_sentence > 0:
@@ -137,7 +136,7 @@ class EpsteinCivilViolence(mesa.Model):
         Helper method to count jailed agents.
         """
         count = 0
-        for agent in model.schedule.agents:
+        for agent in model.agents:
             if agent.breed == "citizen" and agent.jail_sentence > 0:
                 count += 1
         return count
@@ -148,7 +147,7 @@ class EpsteinCivilViolence(mesa.Model):
         Helper method to count jailed agents.
         """
         count = 0
-        for agent in model.schedule.agents:
+        for agent in model.agents:
             if agent.breed == "cop":
                 count += 1
         return count

--- a/examples/forest_fire/Forest Fire Model.ipynb
+++ b/examples/forest_fire/Forest Fire Model.ipynb
@@ -35,8 +35,7 @@
     "from mesa import Agent, Model\n",
     "from mesa.batchrunner import BatchRunner\n",
     "from mesa.datacollection import DataCollector\n",
-    "from mesa.space import Grid\n",
-    "from mesa.time import RandomActivation"
+    "from mesa.space import Grid"
    ]
   },
   {
@@ -129,7 +128,6 @@
     "            density: What fraction of grid cells have a tree in them.\n",
     "        \"\"\"\n",
     "        # Set up model objects\n",
-    "        self.schedule = RandomActivation(self)\n",
     "        self.grid = Grid(width, height, torus=False)\n",
     "        self.dc = DataCollector(\n",
     "            {\n",
@@ -149,14 +147,13 @@
     "                    if x == 0:\n",
     "                        new_tree.condition = \"On Fire\"\n",
     "                    self.grid[x][y] = new_tree\n",
-    "                    self.schedule.add(new_tree)\n",
     "        self.running = True\n",
     "\n",
     "    def step(self):\n",
     "        \"\"\"\n",
     "        Advance the model by one step.\n",
     "        \"\"\"\n",
-    "        self.schedule.step()\n",
+    "        self.agents.shuffle().do(\"step\")\n",
     "        self.dc.collect(self)\n",
     "        # Halt if no more fire\n",
     "        if self.count_type(self, \"On Fire\") == 0:\n",
@@ -168,7 +165,7 @@
     "        Helper method to count trees in a given condition in a given model.\n",
     "        \"\"\"\n",
     "        count = 0\n",
-    "        for tree in model.schedule.agents:\n",
+    "        for tree in model.agents:\n",
     "            if tree.condition == tree_condition:\n",
     "                count += 1\n",
     "        return count"
@@ -339,9 +336,7 @@
    "source": [
     "# At the end of each model run, calculate the fraction of trees which are Burned Out\n",
     "model_reporter = {\n",
-    "    \"BurnedOut\": lambda m: (\n",
-    "        ForestFire.count_type(m, \"Burned Out\") / m.schedule.get_agent_count()\n",
-    "    )\n",
+    "    \"BurnedOut\": lambda m: (ForestFire.count_type(m, \"Burned Out\") / len(m.agents))\n",
     "}"
    ]
   },

--- a/examples/forest_fire/forest_fire/model.py
+++ b/examples/forest_fire/forest_fire/model.py
@@ -18,7 +18,7 @@ class ForestFire(mesa.Model):
         """
         super().__init__()
         # Set up model objects
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.grid = mesa.space.SingleGrid(width, height, torus=False)
 
         self.datacollector = mesa.DataCollector(
@@ -38,7 +38,6 @@ class ForestFire(mesa.Model):
                 if x == 0:
                     new_tree.condition = "On Fire"
                 self.grid.place_agent(new_tree, (x, y))
-                self.schedule.add(new_tree)
 
         self.running = True
         self.datacollector.collect(self)
@@ -47,7 +46,7 @@ class ForestFire(mesa.Model):
         """
         Advance the model by one step.
         """
-        self.schedule.step()
+        self.agents.shuffle().do("step")
         # collect data
         self.datacollector.collect(self)
 
@@ -61,7 +60,7 @@ class ForestFire(mesa.Model):
         Helper method to count trees in a given condition in a given model.
         """
         count = 0
-        for tree in model.schedule.agents:
+        for tree in model.agents:
             if tree.condition == tree_condition:
                 count += 1
         return count

--- a/examples/hex_snowflake/hex_snowflake/cell.py
+++ b/examples/hex_snowflake/hex_snowflake/cell.py
@@ -29,7 +29,7 @@ class Cell(mesa.Agent):
     def considered(self):
         return self.isConsidered is True
 
-    def step(self):
+    def determine_state(self):
         """
         Compute if the cell will be dead or alive at the next tick. A dead
         cell will become alive if it has only one neighbor. The state is not
@@ -53,8 +53,8 @@ class Cell(mesa.Agent):
                 for a in self.neighbors:
                     a.isConsidered = True
 
-    def advance(self):
+    def assume_state(self):
         """
-        Set the state to the new computed state -- computed in step().
+        Set the state to the new computed state
         """
         self.state = self._nextState

--- a/examples/hex_snowflake/hex_snowflake/model.py
+++ b/examples/hex_snowflake/hex_snowflake/model.py
@@ -14,14 +14,6 @@ class HexSnowflake(mesa.Model):
         Create a new playing area of (width, height) cells.
         """
         super().__init__()
-        # Set up the grid and schedule.
-
-        # Use SimultaneousActivation which simulates all the cells
-        # computing their next state simultaneously.  This needs to
-        # be done because each cell's next state depends on the current
-        # state of all its neighbors -- before they've changed.
-        self.schedule = mesa.time.SimultaneousActivation(self)
-
         # Use a hexagonal grid, where edges wrap around.
         self.grid = mesa.space.HexSingleGrid(width, height, torus=True)
 
@@ -29,7 +21,6 @@ class HexSnowflake(mesa.Model):
         for contents, pos in self.grid.coord_iter():
             cell = Cell(pos, self)
             self.grid.place_agent(cell, pos)
-            self.schedule.add(cell)
 
         # activate the center(ish) cell.
         centerishCell = self.grid[width // 2][height // 2]
@@ -42,6 +33,9 @@ class HexSnowflake(mesa.Model):
 
     def step(self):
         """
-        Have the scheduler advance each cell by one step
+        Perform the model step in two stages:
+        - First, all cells assume their next state (whether they will be dead or alive)
+        - Then, all cells change state to their next state
         """
-        self.schedule.step()
+        self.agents.do("determine_state")
+        self.agents.do("assume_state")

--- a/examples/hotelling_law/app.py
+++ b/examples/hotelling_law/app.py
@@ -121,7 +121,7 @@ def space_drawer(model, agent_portrayal):
     cell_store_contents = {}  # Track store agents in each cell
     jitter_amount = 0.3  # Jitter for visual separation
 
-    for agent in model.schedule.agents:
+    for agent in model.agents:
         portrayal = agent_portrayal(agent)
 
         # Track store agents for cell coloring
@@ -150,7 +150,7 @@ def space_drawer(model, agent_portrayal):
             ax.add_patch(rect)
 
     # Jittered scatter plot for all agents
-    for agent in model.schedule.agents:
+    for agent in model.agents:
         portrayal = agent_portrayal(agent)
         jitter_x = np.random.uniform(-jitter_amount, jitter_amount) + agent.pos[0] + 0.5
         jitter_y = np.random.uniform(-jitter_amount, jitter_amount) + agent.pos[1] + 0.5
@@ -177,9 +177,7 @@ def make_market_share_and_price_chart(model):
 
     # Get store agents and sort them by their unique_id
     # to ensure consistent order
-    store_agents = [
-        agent for agent in model.schedule.agents if isinstance(agent, StoreAgent)
-    ]
+    store_agents = [agent for agent in model.agents if isinstance(agent, StoreAgent)]
     store_agents_sorted = sorted(store_agents, key=lambda agent: agent.unique_id)
 
     # Now gather market shares, prices, and labels using the sorted list
@@ -241,7 +239,7 @@ def make_price_changes_line_chart(model):
     # Retrieve agent colors based on their portrayal
     agent_colors = {
         f"Store_{agent.unique_id}_Price": agent_portrayal(agent)["color"]
-        for agent in model.schedule.agents
+        for agent in model.agents
         if isinstance(agent, StoreAgent)
     }
 
@@ -277,7 +275,7 @@ def make_market_share_line_chart(model):
     # Retrieve agent colors based on their portrayal
     agent_colors = {
         f"Store_{agent.unique_id}_Market Share": agent_portrayal(agent)["color"]
-        for agent in model.schedule.agents
+        for agent in model.agents
         if isinstance(agent, StoreAgent)
     }
 
@@ -313,7 +311,7 @@ def make_revenue_line_chart(model):
     # Retrieve agent colors based on their portrayal
     agent_colors = {
         f"Store_{agent.unique_id}_Revenue": agent_portrayal(agent)["color"]
-        for agent in model.schedule.agents
+        for agent in model.agents
         if isinstance(agent, StoreAgent)
     }
 

--- a/examples/hotelling_law/hotelling_law/agents.py
+++ b/examples/hotelling_law/hotelling_law/agents.py
@@ -119,7 +119,7 @@ class StoreAgent(Agent):
 
     def identify_competitors(self):
         competitors = []
-        for agent in self.model.schedule.agents:
+        for agent in self.model.agents:
             if isinstance(agent, StoreAgent) and agent.unique_id != self.unique_id:
                 # Estimate market overlap as a measure of competition
                 overlap = self.estimate_market_overlap(agent)

--- a/examples/hotelling_law/hotelling_law/model.py
+++ b/examples/hotelling_law/hotelling_law/model.py
@@ -5,7 +5,6 @@ from mesa import Model
 from mesa.agent import AgentSet
 from mesa.datacollection import DataCollector
 from mesa.space import MultiGrid
-from mesa.time import RandomActivation
 
 from .agents import ConsumerAgent, StoreAgent
 
@@ -94,8 +93,6 @@ class HotellingModel(Model):
         self.consumer_preferences = consumer_preferences
         # Type of environment ('grid' or 'line').
         self.environment_type = environment_type
-        # Scheduler to activate agents one at a time, in random order.
-        self.schedule = RandomActivation(self)
         # Initialize AgentSets for store and consumer agents
         self.store_agents = AgentSet([], self)
         self.consumer_agents = AgentSet([], self)
@@ -188,7 +185,7 @@ class HotellingModel(Model):
                 mobile_agents_assigned += 1
 
             agent = StoreAgent(unique_id, self, can_move=can_move, strategy=strategy)
-            self.schedule.add(agent)
+
             self.store_agents.add(agent)
 
             # Randomly place agents on the grid for a grid environment.
@@ -200,7 +197,7 @@ class HotellingModel(Model):
         for i in range(self.num_consumers):
             # Ensure unique ID across all agents
             consumer = ConsumerAgent(self.num_agents + i, self)
-            self.schedule.add(consumer)
+
             self.consumer_agents.add(consumer)
             # Place consumer randomly on the grid
             x = self.random.randrange(self.grid.width)
@@ -218,8 +215,8 @@ class HotellingModel(Model):
         """Advance the model by one step."""
         # Collect data for the current step.
         self.datacollector.collect(self)
-        # Activate the next agent in the schedule.
-        self.schedule.step()
+        # Activate all agents in random order
+        self.agents.shuffle().do("step")
         # Update market dynamics based on the latest actions
         self.recalculate_market_share()
 

--- a/examples/schelling/model.py
+++ b/examples/schelling/model.py
@@ -68,7 +68,6 @@ class Schelling(mesa.Model):
         self.homophily = homophily
         self.radius = radius
 
-        self.schedule = mesa.time.RandomActivation(self)
         self.grid = mesa.space.SingleGrid(width, height, torus=True)
 
         self.happy = 0
@@ -85,7 +84,6 @@ class Schelling(mesa.Model):
                 agent_type = 1 if self.random.random() < self.minority_pc else 0
                 agent = SchellingAgent(self.next_id(), self, agent_type)
                 self.grid.place_agent(agent, pos)
-                self.schedule.add(agent)
 
         self.datacollector.collect(self)
 
@@ -94,9 +92,9 @@ class Schelling(mesa.Model):
         Run one step of the model.
         """
         self.happy = 0  # Reset counter of happy agents
-        self.schedule.step()
+        self.agents.shuffle().do("step")
 
         self.datacollector.collect(self)
 
-        if self.happy == self.schedule.get_agent_count():
+        if self.happy == len(self.agents):
             self.running = False

--- a/examples/shape_example/shape_example/model.py
+++ b/examples/shape_example/shape_example/model.py
@@ -14,7 +14,7 @@ class ShapeExample(mesa.Model):
         self.N = N  # num of agents
         self.headings = ((1, 0), (0, 1), (-1, 0), (0, -1))  # tuples are fast
         self.grid = mesa.space.SingleGrid(width, height, torus=False)
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.make_walker_agents()
         self.running = True
 
@@ -31,9 +31,9 @@ class ShapeExample(mesa.Model):
             if self.grid.is_cell_empty(pos):
                 print(f"Creating agent {unique_id} at ({x}, {y})")
                 a = Walker(unique_id, self, heading)
-                self.schedule.add(a)
+
                 self.grid.place_agent(a, pos)
                 unique_id += 1
 
     def step(self):
-        self.schedule.step()
+        self.agents.shuffle().do("step")

--- a/examples/virus_on_network/virus_on_network/model.py
+++ b/examples/virus_on_network/virus_on_network/model.py
@@ -47,7 +47,7 @@ class VirusOnNetwork(mesa.Model):
         prob = avg_node_degree / self.num_nodes
         self.G = nx.erdos_renyi_graph(n=self.num_nodes, p=prob)
         self.grid = mesa.space.NetworkGrid(self.G)
-        self.schedule = mesa.time.RandomActivation(self)
+
         self.initial_outbreak_size = (
             initial_outbreak_size if initial_outbreak_size <= num_nodes else num_nodes
         )
@@ -75,7 +75,7 @@ class VirusOnNetwork(mesa.Model):
                 self.recovery_chance,
                 self.gain_resistance_chance,
             )
-            self.schedule.add(a)
+
             # Add the agent to the node
             self.grid.place_agent(a, node)
 
@@ -96,7 +96,7 @@ class VirusOnNetwork(mesa.Model):
             return math.inf
 
     def step(self):
-        self.schedule.step()
+        self.agents.shuffle().do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/test_examples.py
+++ b/test_examples.py
@@ -32,3 +32,4 @@ def test_model_steps(model_class):
     model = model_class()  # Assume no arguments are needed
     for _ in range(10):
         model.step()
+    assert model.steps == 10


### PR DESCRIPTION
This reinstates PR #161 after the previous revert in #170.

Now that https://github.com/projectmesa/mesa/pull/2223 is merged, these examples are fully functional again without schedulers.

Original description of #161 below.

<hr>

This PR replace all the `RandomActivation` and `SimultaneousActivation` schedulers used in the example models with AgentSet functionality. This simplifies models and allows for easier and more flexible modification of these models. It algins the examples with the current best practices in Mesa.

### RandomActivation
The RandomActivation schedulers were removed, and in the Model.step() function the schedule step was replaced with an AgentSet operation, like:

```diff
-        self.schedule.step()
+        self.agents.shuffle().do("step")
```

The following RandomActivation schedulers were removed:
- bank_reserves
- boid_flockers
- boltzmann_wealth_model
- boltzmann_wealth_model_experimental
- boltzmann_wealth_model_network
- caching_and_replay
- charts
- el_farol
- epstein_civil_violence
- forest_fire
- hotelling_law
- schelling
- shape_example
- virus_on_network

### SimultaneousActivation
To remove the SimultaneousActivation schedulers, the Agent methods were renamed from `step()` and `advance()` to more descriptive functions. The model step was updated accordingly:

```diff
-        self.schedule.step()
+        self.agents.do("determine_state")
+        self.agents.do("assume_state")
```

The following SimultaneousActivation schedulers were removed:
- hex_snowflake
- color_patches
- conways_game_of_life

**Relevant tickets**
- https://github.com/projectmesa/mesa-examples/issues/111
- https://github.com/projectmesa/mesa/discussions/1912
- https://github.com/projectmesa/mesa/pull/1916
- https://github.com/projectmesa/mesa/pull/2223