### PR TITLE
gis: Use gzip.open opener in RasterLayer.from_file

### DIFF
--- a/gis/population/population/space.py
+++ b/gis/population/population/space.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import uuid
 
 import geopandas as gpd
@@ -36,9 +37,10 @@ class UgandaArea(GeoSpace):
     def load_data(self, population_gzip_file, lake_zip_file, world_zip_file, model):
         world_size = gpd.GeoDataFrame.from_file(world_zip_file)
         raster_layer = RasterLayer.from_file(
-            f"/vsigzip/{population_gzip_file}",
+            population_gzip_file,
             cell_cls=UgandaCell,
             attr_name="population",
+            rio_opener=gzip.open,
         )
         raster_layer.crs = world_size.crs
         raster_layer.total_bounds = world_size.total_bounds

--- a/gis/rainfall/rainfall/space.py
+++ b/gis/rainfall/rainfall/space.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import gzip
+
 import mesa
 import mesa_geo as mg
 import numpy as np
@@ -34,9 +36,10 @@ class CraterLake(mg.GeoSpace):
 
     def set_elevation_layer(self, elevation_gzip_file, crs):
         raster_layer = mg.RasterLayer.from_file(
-            f"/vsigzip/{elevation_gzip_file}",
+            elevation_gzip_file,
             cell_cls=LakeCell,
             attr_name="elevation",
+            rio_opener=gzip.open,
         )
         raster_layer.crs = crs
         raster_layer.apply_raster(

--- a/gis/urban_growth/urban_growth/space.py
+++ b/gis/urban_growth/urban_growth/space.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import random
 
 import mesa
@@ -96,7 +97,7 @@ class City(mg.GeoSpace):
             "land_use": land_use_data,
         }
         for attribute_name, data_file in data.items():
-            with rio.open(f"/vsigzip/{data_file}", "r") as dataset:
+            with rio.open(data_file, "r", opener=gzip.open) as dataset:
                 values = dataset.read()
             self.raster_layer.apply_raster(values, attr_name=attribute_name)
 


### PR DESCRIPTION
Use pass the new `rio_opener` argument with `gzip.open` in `RasterLayer.from_file()`. This prevents having to do the weird `/vsigzip/` stuff.

Note that urban_growth uses the rasterio opener directly, while the other two examples pass it via the mesa_geo.raster_layers.RasterLayer.open_file() method.

- Follow up on https://github.com/projectmesa/mesa-examples/pull/177
- Enabled by https://github.com/projectmesa/mesa-geo/pull/237
- Part of https://github.com/projectmesa/mesa-geo/issues/235
- Part of https://github.com/projectmesa/mesa-examples/issues/172