### PR TITLE
gis: Pass `model` to `RasterLayer.from_file()`

### DIFF
--- a/gis/population/population/space.py
+++ b/gis/population/population/space.py
@@ -37,6 +37,7 @@ class UgandaArea(GeoSpace):
         world_size = gpd.GeoDataFrame.from_file(world_zip_file)
         raster_layer = RasterLayer.from_file(
             f"/vsigzip/{population_gzip_file}",
+            model=model,
             cell_cls=UgandaCell,
             attr_name="population",
         )

--- a/gis/rainfall/rainfall/space.py
+++ b/gis/rainfall/rainfall/space.py
@@ -35,6 +35,7 @@ class CraterLake(mg.GeoSpace):
     def set_elevation_layer(self, elevation_gzip_file, crs):
         raster_layer = mg.RasterLayer.from_file(
             f"/vsigzip/{elevation_gzip_file}",
+            model=self.model,
             cell_cls=LakeCell,
             attr_name="elevation",
         )


### PR DESCRIPTION
Fixes the _population_ and _rainfall_ models by passing `model` to `RasterLayer.from_file()`. 

> The RasterLayer creates Cells, Cells inherit from Agents, Agents need model input, but RasterLayer doesn't have access to model.

This reduces the number of GIS models that error by two, with now only one warning and one error left.

- As described in https://github.com/projectmesa/mesa-geo/issues/236
- Enabled by https://github.com/projectmesa/mesa-geo/pull/240
- Part of https://github.com/projectmesa/mesa-examples/issues/172