### PR TITLE
Replace `get_agents_of_type` method with `agents_by_type` property

### DIFF
--- a/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
+++ b/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
@@ -73,12 +73,12 @@ class SugarscapeG1mt(mesa.Model):
         # initiate datacollector
         self.datacollector = mesa.DataCollector(
             model_reporters={
-                "Trader": lambda m: len(m.get_agents_of_type(Trader)),
+                "Trader": lambda m: len(m.agents_by_type[Trader]),
                 "Trade Volume": lambda m: sum(
-                    len(a.trade_partners) for a in m.get_agents_of_type(Trader)
+                    len(a.trade_partners) for a in m.agents_by_type[Trader]
                 ),
                 "Price": lambda m: geometric_mean(
-                    flatten([a.prices for a in m.get_agents_of_type(Trader)])
+                    flatten([a.prices for a in m.agents_by_type[Trader]])
                 ),
             },
             agent_reporters={"Trade Network": lambda a: get_trade(a)},
@@ -134,12 +134,12 @@ class SugarscapeG1mt(mesa.Model):
         and then randomly activates traders
         """
         # step Resource agents
-        self.get_agents_of_type(Resource).do("step")
+        self.agents_by_type[Resource].do("step")
 
         # step trader agents
         # to account for agent death and removal we need a seperate data strcuture to
         # iterate
-        trader_shuffle = self.get_agents_of_type(Trader).shuffle()
+        trader_shuffle = self.agents_by_type[Trader].shuffle()
 
         for agent in trader_shuffle:
             agent.prices = []
@@ -153,7 +153,7 @@ class SugarscapeG1mt(mesa.Model):
             self.datacollector.collect(self)
             return
 
-        trader_shuffle = self.get_agents_of_type(Trader).shuffle()
+        trader_shuffle = self.agents_by_type[Trader].shuffle()
 
         for agent in trader_shuffle:
             agent.trade_with_neighbors()

--- a/examples/wolf_sheep/wolf_sheep/model.py
+++ b/examples/wolf_sheep/wolf_sheep/model.py
@@ -81,12 +81,12 @@ class WolfSheep(mesa.Model):
         self.grid = mesa.space.MultiGrid(self.width, self.height, torus=True)
 
         collectors = {
-            "Wolves": lambda m: len(m.get_agents_of_type(Wolf)),
-            "Sheep": lambda m: len(m.get_agents_of_type(Sheep)),
+            "Wolves": lambda m: len(m.agents_by_type[Wolf]),
+            "Sheep": lambda m: len(m.agents_by_type[Sheep]),
         }
 
         if grass:
-            collectors["Grass"] = lambda m: len(m.get_agents_of_type(GrassPatch))
+            collectors["Grass"] = lambda m: len(m.agents_by_type[GrassPatch])
 
         self.datacollector = mesa.DataCollector(collectors)
 
@@ -128,7 +128,7 @@ class WolfSheep(mesa.Model):
         # Conceptually, it can be argued that this should be modelled differently.
         self.random.shuffle(self.agent_types)
         for agent_type in self.agent_types:
-            self.get_agents_of_type(agent_type).do("step")
+            self.agents_by_type[agent_type].do("step")
 
         # collect data
         self.datacollector.collect(self)


### PR DESCRIPTION
This PR updates the examples now that this PR is merged:
- https://github.com/projectmesa/mesa/pull/2267

The Model method `get_agents_of_type()` is replaced by the `agents_by_type` property, which directly returns the dict.

Instead of using:
```Python
model.get_agents_of_type(Wolf)
```
You should now use:
```Python
model.agents_by_type[Wolf]
```