### PR TITLE
remove unique_id and model.next_id

### DIFF
--- a/examples/aco_tsp/aco_tsp/model.py
+++ b/examples/aco_tsp/aco_tsp/model.py
@@ -82,14 +82,13 @@ class AntTSP(mesa.Agent):
     An agent
     """
 
-    def __init__(self, unique_id, model, alpha: float = 1.0, beta: float = 5.0):
+    def __init__(self, model, alpha: float = 1.0, beta: float = 5.0):
         """
         Customize the agent
         """
-        self.unique_id = unique_id
+        super().__init__(model)
         self.alpha = alpha
         self.beta = beta
-        super().__init__(unique_id, model)
         self._cities_visited = []
         self._traveled_distance = 0
         self.tsp_solution = []
@@ -176,8 +175,8 @@ class AcoTspModel(mesa.Model):
         self.max_steps = max_steps
         self.grid = mesa.space.NetworkGrid(tsp_graph.g)
 
-        for i in range(self.num_agents):
-            agent = AntTSP(unique_id=i, model=self, alpha=ant_alpha, beta=ant_beta)
+        for _ in range(self.num_agents):
+            agent = AntTSP(model=self, alpha=ant_alpha, beta=ant_beta)
 
             city = tsp_graph.cities[self.random.randrange(self.num_cities)]
             self.grid.place_agent(agent, city)

--- a/examples/bank_reserves/bank_reserves/agents.py
+++ b/examples/bank_reserves/bank_reserves/agents.py
@@ -45,9 +45,9 @@ class Bank:
 
 # subclass of RandomWalker, which is subclass to Mesa Agent
 class Person(RandomWalker):
-    def __init__(self, unique_id, model, moore, bank, rich_threshold):
+    def __init__(self, model, moore, bank, rich_threshold):
         # init parent class with required parameters
-        super().__init__(unique_id, model, moore=moore)
+        super().__init__(model, moore=moore)
         # the amount each person has in savings
         self.savings = 0
         # total loan amount person has outstanding

--- a/examples/bank_reserves/bank_reserves/model.py
+++ b/examples/bank_reserves/bank_reserves/model.py
@@ -139,11 +139,11 @@ class BankReserves(mesa.Model):
         self.bank = Bank(self, self.reserve_percent)
 
         # create people for the model according to number of people set by user
-        for i in range(self.init_people):
+        for _ in range(self.init_people):
             # set x, y coords randomly within the grid
             x = self.random.randrange(self.width)
             y = self.random.randrange(self.height)
-            p = Person(i, self, True, self.bank, self.rich_threshold)
+            p = Person(self, True, self.bank, self.rich_threshold)
             # place the Person object on the grid at coordinates (x, y)
             self.grid.place_agent(p, (x, y))
 

--- a/examples/bank_reserves/bank_reserves/random_walk.py
+++ b/examples/bank_reserves/bank_reserves/random_walk.py
@@ -24,7 +24,7 @@ class RandomWalker(mesa.Agent):
     # use a Moore neighborhood
     moore = True
 
-    def __init__(self, unique_id, model, moore=True):
+    def __init__(self, model, moore=True):
         """
         grid: The MultiGrid object in which the agent lives.
         x: The agent's current x coordinate
@@ -32,7 +32,7 @@ class RandomWalker(mesa.Agent):
         moore: If True, may move in all 8 directions.
                 Otherwise, only up, down, left, right.
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.moore = moore
 
     def random_move(self):

--- a/examples/boid_flockers/boid_flockers/model.py
+++ b/examples/boid_flockers/boid_flockers/model.py
@@ -26,7 +26,6 @@ class Boid(mesa.Agent):
 
     def __init__(
         self,
-        unique_id,
         model,
         speed,
         direction,
@@ -40,7 +39,6 @@ class Boid(mesa.Agent):
         Create a new Boid flocker agent.
 
         Args:
-            unique_id: Unique agent identifier.
             speed: Distance to move per step.
             direction: numpy vector for the Boid's direction of movement.
             vision: Radius to look around for nearby Boids.
@@ -49,7 +47,7 @@ class Boid(mesa.Agent):
             separate: the relative importance of avoiding close neighbors
             match: the relative importance of matching neighbors' headings
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.speed = speed
         self.direction = direction
         self.vision = vision
@@ -129,13 +127,12 @@ class BoidFlockers(mesa.Model):
         """
         Create self.population agents, with random positions and starting headings.
         """
-        for i in range(self.population):
+        for _ in range(self.population):
             x = self.random.random() * self.space.x_max
             y = self.random.random() * self.space.y_max
             pos = np.array((x, y))
             direction = np.random.random(2) * 2 - 1
             boid = Boid(
-                unique_id=i,
                 model=self,
                 speed=self.speed,
                 direction=direction,

--- a/examples/boltzmann_wealth_model/boltzmann_wealth_model/model.py
+++ b/examples/boltzmann_wealth_model/boltzmann_wealth_model/model.py
@@ -27,7 +27,7 @@ class BoltzmannWealthModel(mesa.Model):
         )
         # Create agents
         for i in range(self.num_agents):
-            a = MoneyAgent(i, self)
+            a = MoneyAgent(self)
 
             # Add the agent to a random grid cell
             x = self.random.randrange(self.grid.width)
@@ -50,8 +50,8 @@ class BoltzmannWealthModel(mesa.Model):
 class MoneyAgent(mesa.Agent):
     """An agent with fixed initial wealth."""
 
-    def __init__(self, unique_id, model):
-        super().__init__(unique_id, model)
+    def __init__(self, model):
+        super().__init__(model)
         self.wealth = 1
 
     def move(self):

--- a/examples/boltzmann_wealth_model/boltzmann_wealth_model/model.py
+++ b/examples/boltzmann_wealth_model/boltzmann_wealth_model/model.py
@@ -26,7 +26,7 @@ class BoltzmannWealthModel(mesa.Model):
             model_reporters={"Gini": compute_gini}, agent_reporters={"Wealth": "wealth"}
         )
         # Create agents
-        for i in range(self.num_agents):
+        for _ in range(self.num_agents):
             a = MoneyAgent(self)
 
             # Add the agent to a random grid cell

--- a/examples/boltzmann_wealth_model_experimental/model.py
+++ b/examples/boltzmann_wealth_model_experimental/model.py
@@ -27,7 +27,7 @@ class BoltzmannWealthModel(mesa.Model):
         )
         # Create agents
         for i in range(self.num_agents):
-            a = MoneyAgent(i, self)
+            a = MoneyAgent(self)
 
             # Add the agent to a random grid cell
             x = self.random.randrange(self.grid.width)
@@ -50,8 +50,8 @@ class BoltzmannWealthModel(mesa.Model):
 class MoneyAgent(mesa.Agent):
     """An agent with fixed initial wealth."""
 
-    def __init__(self, unique_id, model):
-        super().__init__(unique_id, model)
+    def __init__(self, model):
+        super().__init__(model)
         self.wealth = 1
 
     def move(self):

--- a/examples/boltzmann_wealth_model_experimental/model.py
+++ b/examples/boltzmann_wealth_model_experimental/model.py
@@ -26,7 +26,7 @@ class BoltzmannWealthModel(mesa.Model):
             model_reporters={"Gini": compute_gini}, agent_reporters={"Wealth": "wealth"}
         )
         # Create agents
-        for i in range(self.num_agents):
+        for _ in range(self.num_agents):
             a = MoneyAgent(self)
 
             # Add the agent to a random grid cell

--- a/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
+++ b/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
@@ -28,7 +28,7 @@ class BoltzmannWealthModelNetwork(mesa.Model):
         list_of_random_nodes = self.random.sample(list(self.G), self.num_agents)
 
         # Create agents
-        for _ in range(self.num_agents):
+        for i in range(self.num_agents):
             a = MoneyAgent(self)
 
             # Add the agent to a random node

--- a/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
+++ b/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
@@ -28,7 +28,7 @@ class BoltzmannWealthModelNetwork(mesa.Model):
         list_of_random_nodes = self.random.sample(list(self.G), self.num_agents)
 
         # Create agents
-        for i in range(self.num_agents):
+        for _ in range(self.num_agents):
             a = MoneyAgent(self)
 
             # Add the agent to a random node

--- a/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
+++ b/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
@@ -29,7 +29,7 @@ class BoltzmannWealthModelNetwork(mesa.Model):
 
         # Create agents
         for i in range(self.num_agents):
-            a = MoneyAgent(i, self)
+            a = MoneyAgent(self)
 
             # Add the agent to a random node
             self.grid.place_agent(a, list_of_random_nodes[i])
@@ -50,8 +50,8 @@ class BoltzmannWealthModelNetwork(mesa.Model):
 class MoneyAgent(mesa.Agent):
     """An agent with fixed initial wealth."""
 
-    def __init__(self, unique_id, model):
-        super().__init__(unique_id, model)
+    def __init__(self, model):
+        super().__init__(model)
         self.wealth = 1
 
     def move(self):

--- a/examples/caching_and_replay/model.py
+++ b/examples/caching_and_replay/model.py
@@ -8,16 +8,15 @@ class SchellingAgent(mesa.Agent):
     Schelling segregation agent
     """
 
-    def __init__(self, unique_id, model, agent_type):
+    def __init__(self, model, agent_type):
         """
         Create a new Schelling agent.
 
         Args:
-           unique_id: Unique identifier for the agent.
            x, y: Agent initial location.
            agent_type: Indicator for the agent's type (minority=1, majority=0)
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.type = agent_type
 
     def step(self):
@@ -84,7 +83,7 @@ class Schelling(mesa.Model):
         for _, pos in self.grid.coord_iter():
             if self.random.random() < self.density:
                 agent_type = 1 if self.random.random() < self.minority_pc else 0
-                agent = SchellingAgent(self.next_id(), self, agent_type)
+                agent = SchellingAgent(self, agent_type)
                 self.grid.place_agent(agent, pos)
 
         self.datacollector.collect(self)

--- a/examples/charts/charts/agents.py
+++ b/examples/charts/charts/agents.py
@@ -45,9 +45,9 @@ class Bank:
 
 # subclass of RandomWalker, which is subclass to Mesa Agent
 class Person(RandomWalker):
-    def __init__(self, unique_id, model, moore, bank, rich_threshold):
+    def __init__(self, model, moore, bank, rich_threshold):
         # init parent class with required parameters
-        super().__init__(unique_id, model, moore=moore)
+        super().__init__(model, moore=moore)
         # the amount each person has in savings
         self.savings = 0
         # total loan amount person has outstanding

--- a/examples/charts/charts/model.py
+++ b/examples/charts/charts/model.py
@@ -122,11 +122,11 @@ class Charts(mesa.Model):
         self.bank = Bank(self, self.reserve_percent)
 
         # create people for the model according to number of people set by user
-        for i in range(self.init_people):
+        for _ in range(self.init_people):
             # set x, y coords randomly within the grid
             x = self.random.randrange(self.width)
             y = self.random.randrange(self.height)
-            p = Person(i, self, True, self.bank, self.rich_threshold)
+            p = Person(self, True, self.bank, self.rich_threshold)
             # place the Person object on the grid at coordinates (x, y)
             self.grid.place_agent(p, (x, y))
 

--- a/examples/charts/charts/random_walk.py
+++ b/examples/charts/charts/random_walk.py
@@ -24,7 +24,7 @@ class RandomWalker(mesa.Agent):
     # use a Moore neighborhood
     moore = True
 
-    def __init__(self, unique_id, model, moore=True):
+    def __init__(self, model, moore=True):
         """
         grid: The MultiGrid object in which the agent lives.
         x: The agent's current x coordinate
@@ -32,7 +32,7 @@ class RandomWalker(mesa.Agent):
         moore: If True, may move in all 8 directions.
                 Otherwise, only up, down, left, right.
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.moore = moore
 
     def random_move(self):

--- a/examples/color_patches/color_patches/model.py
+++ b/examples/color_patches/color_patches/model.py
@@ -18,7 +18,7 @@ class ColorCell(mesa.Agent):
         """
         Create a cell, in the given state, at the given row, col position.
         """
-        super().__init__(pos, model)
+        super().__init__(model)
         self._row = pos[0]
         self._col = pos[1]
         self._state = initial_state

--- a/examples/conways_game_of_life/conways_game_of_life/cell.py
+++ b/examples/conways_game_of_life/conways_game_of_life/cell.py
@@ -11,7 +11,7 @@ class Cell(mesa.Agent):
         """
         Create a cell, in the given state, at the given x, y position.
         """
-        super().__init__(pos, model)
+        super().__init__(model)
         self.x, self.y = pos
         self.state = init_state
         self._nextState = None

--- a/examples/el_farol/el_farol/agents.py
+++ b/examples/el_farol/el_farol/agents.py
@@ -3,8 +3,8 @@ import numpy as np
 
 
 class BarCustomer(mesa.Agent):
-    def __init__(self, unique_id, model, memory_size, crowd_threshold, num_strategies):
-        super().__init__(unique_id, model)
+    def __init__(self, model, memory_size, crowd_threshold, num_strategies):
+        super().__init__(model)
         # Random values from -1.0 to 1.0
         self.strategies = np.random.rand(num_strategies, memory_size + 1) * 2 - 1
         self.best_strategy = self.strategies[0]

--- a/examples/el_farol/el_farol/model.py
+++ b/examples/el_farol/el_farol/model.py
@@ -23,8 +23,8 @@ class ElFarolBar(mesa.Model):
         # strategies would have worked.
         self.history = np.random.randint(0, 100, size=memory_size * 2).tolist()
         self.attendance = self.history[-1]
-        for i in range(self.num_agents):
-            BarCustomer(i, self, memory_size, crowd_threshold, num_strategies)
+        for _ in range(self.num_agents):
+            BarCustomer(self, memory_size, crowd_threshold, num_strategies)
 
         self.datacollector = mesa.DataCollector(
             model_reporters={"Customers": "attendance"},

--- a/examples/epstein_civil_violence/epstein_civil_violence/agent.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/agent.py
@@ -9,7 +9,6 @@ class Citizen(mesa.Agent):
     Summary of rule: If grievance - risk > threshold, rebel.
 
     Attributes:
-        unique_id: unique int
         x, y: Grid coordinates
         hardship: Agent's 'perceived hardship (i.e., physical or economic
             privation).' Exogenous, drawn from U(0,1).
@@ -30,7 +29,6 @@ class Citizen(mesa.Agent):
 
     def __init__(
         self,
-        unique_id,
         model,
         pos,
         hardship,
@@ -42,7 +40,6 @@ class Citizen(mesa.Agent):
         """
         Create a new Citizen.
         Args:
-            unique_id: unique int
             x, y: Grid coordinates
             hardship: Agent's 'perceived hardship (i.e., physical or economic
                 privation).' Exogenous, drawn from U(0,1).
@@ -55,7 +52,7 @@ class Citizen(mesa.Agent):
                 agent can inspect. Exogenous.
             model: model instance
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.breed = "citizen"
         self.pos = pos
         self.hardship = hardship
@@ -129,17 +126,16 @@ class Cop(mesa.Agent):
             able to inspect
     """
 
-    def __init__(self, unique_id, model, pos, vision):
+    def __init__(self, model, pos, vision):
         """
         Create a new Cop.
         Args:
-            unique_id: unique int
             x, y: Grid coordinates
             vision: number of cells in each direction (N, S, E and W) that
                 agent can inspect. Exogenous.
             model: model instance
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.breed = "cop"
         self.pos = pos
         self.vision = vision

--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -78,18 +78,16 @@ class EpsteinCivilViolence(mesa.Model):
         self.datacollector = mesa.DataCollector(
             model_reporters=model_reporters, agent_reporters=agent_reporters
         )
-        unique_id = 0
         if self.cop_density + self.citizen_density > 1:
             raise ValueError("Cop density + citizen density must be less than 1")
+
         for contents, (x, y) in self.grid.coord_iter():
             if self.random.random() < self.cop_density:
-                cop = Cop(unique_id, self, (x, y), vision=self.cop_vision)
-                unique_id += 1
+                cop = Cop(self, (x, y), vision=self.cop_vision)
                 self.grid[x][y] = cop
 
             elif self.random.random() < (self.cop_density + self.citizen_density):
                 citizen = Citizen(
-                    unique_id,
                     self,
                     (x, y),
                     hardship=self.random.random(),
@@ -98,7 +96,6 @@ class EpsteinCivilViolence(mesa.Model):
                     threshold=self.active_threshold,
                     vision=self.citizen_vision,
                 )
-                unique_id += 1
                 self.grid[x][y] = citizen
 
         self.running = True

--- a/examples/forest_fire/Forest Fire Model.ipynb
+++ b/examples/forest_fire/Forest Fire Model.ipynb
@@ -35,8 +35,7 @@
     "from mesa import Agent, Model\n",
     "from mesa.batchrunner import BatchRunner\n",
     "from mesa.datacollection import DataCollector\n",
-    "from mesa.space import Grid\n",
-    "from mesa.time import RandomActivation"
+    "from mesa.space import Grid"
    ]
   },
   {
@@ -66,18 +65,16 @@
     "        x, y: Grid coordinates\n",
     "        condition: Can be \"Fine\", \"On Fire\", or \"Burned Out\"\n",
     "        unique_id: int\n",
-    "\n",
     "    \"\"\"\n",
     "\n",
     "    def __init__(self, model, pos):\n",
     "        \"\"\"\n",
     "        Create a new tree.\n",
     "        Args:\n",
-    "            pos: The tree's coordinates on the grid. Used as the unique_id\n",
+    "            pos: The tree's coordinates on the grid.\n",
     "        \"\"\"\n",
     "        super().__init__(model)\n",
     "        self.pos = pos\n",
-    "        self.unique_id = pos\n",
     "        self.condition = \"Fine\"\n",
     "\n",
     "    def step(self):\n",
@@ -127,7 +124,6 @@
     "            density: What fraction of grid cells have a tree in them.\n",
     "        \"\"\"\n",
     "        # Set up model objects\n",
-    "        self.schedule = RandomActivation(self)\n",
     "        self.grid = Grid(width, height, torus=False)\n",
     "        self.dc = DataCollector(\n",
     "            {\n",
@@ -147,14 +143,13 @@
     "                    if x == 0:\n",
     "                        new_tree.condition = \"On Fire\"\n",
     "                    self.grid[x][y] = new_tree\n",
-    "                    self.schedule.add(new_tree)\n",
     "        self.running = True\n",
     "\n",
     "    def step(self):\n",
     "        \"\"\"\n",
     "        Advance the model by one step.\n",
     "        \"\"\"\n",
-    "        self.schedule.step()\n",
+    "        self.agents.shuffle().do(\"step\")\n",
     "        self.dc.collect(self)\n",
     "        # Halt if no more fire\n",
     "        if self.count_type(self, \"On Fire\") == 0:\n",
@@ -166,7 +161,7 @@
     "        Helper method to count trees in a given condition in a given model.\n",
     "        \"\"\"\n",
     "        count = 0\n",
-    "        for tree in model.schedule.agents:\n",
+    "        for tree in model.agents:\n",
     "            if tree.condition == tree_condition:\n",
     "                count += 1\n",
     "        return count"
@@ -337,9 +332,7 @@
    "source": [
     "# At the end of each model run, calculate the fraction of trees which are Burned Out\n",
     "model_reporter = {\n",
-    "    \"BurnedOut\": lambda m: (\n",
-    "        ForestFire.count_type(m, \"Burned Out\") / m.schedule.get_agent_count()\n",
-    "    )\n",
+    "    \"BurnedOut\": lambda m: (ForestFire.count_type(m, \"Burned Out\") / len(m.agents))\n",
     "}"
    ]
   },

--- a/examples/forest_fire/Forest Fire Model.ipynb
+++ b/examples/forest_fire/Forest Fire Model.ipynb
@@ -35,7 +35,8 @@
     "from mesa import Agent, Model\n",
     "from mesa.batchrunner import BatchRunner\n",
     "from mesa.datacollection import DataCollector\n",
-    "from mesa.space import Grid"
+    "from mesa.space import Grid\n",
+    "from mesa.time import RandomActivation"
    ]
   },
   {
@@ -64,10 +65,8 @@
     "    Attributes:\n",
     "        x, y: Grid coordinates\n",
     "        condition: Can be \"Fine\", \"On Fire\", or \"Burned Out\"\n",
-    "        unique_id: (x,y) tuple.\n",
+    "        unique_id: int\n",
     "\n",
-    "    unique_id isn't strictly necessary here, but it's good practice to give one to each\n",
-    "    agent anyway.\n",
     "    \"\"\"\n",
     "\n",
     "    def __init__(self, model, pos):\n",
@@ -76,7 +75,7 @@
     "        Args:\n",
     "            pos: The tree's coordinates on the grid. Used as the unique_id\n",
     "        \"\"\"\n",
-    "        super().__init__(pos, model)\n",
+    "        super().__init__(model)\n",
     "        self.pos = pos\n",
     "        self.unique_id = pos\n",
     "        self.condition = \"Fine\"\n",
@@ -128,6 +127,7 @@
     "            density: What fraction of grid cells have a tree in them.\n",
     "        \"\"\"\n",
     "        # Set up model objects\n",
+    "        self.schedule = RandomActivation(self)\n",
     "        self.grid = Grid(width, height, torus=False)\n",
     "        self.dc = DataCollector(\n",
     "            {\n",
@@ -147,13 +147,14 @@
     "                    if x == 0:\n",
     "                        new_tree.condition = \"On Fire\"\n",
     "                    self.grid[x][y] = new_tree\n",
+    "                    self.schedule.add(new_tree)\n",
     "        self.running = True\n",
     "\n",
     "    def step(self):\n",
     "        \"\"\"\n",
     "        Advance the model by one step.\n",
     "        \"\"\"\n",
-    "        self.agents.shuffle().do(\"step\")\n",
+    "        self.schedule.step()\n",
     "        self.dc.collect(self)\n",
     "        # Halt if no more fire\n",
     "        if self.count_type(self, \"On Fire\") == 0:\n",
@@ -165,7 +166,7 @@
     "        Helper method to count trees in a given condition in a given model.\n",
     "        \"\"\"\n",
     "        count = 0\n",
-    "        for tree in model.agents:\n",
+    "        for tree in model.schedule.agents:\n",
     "            if tree.condition == tree_condition:\n",
     "                count += 1\n",
     "        return count"
@@ -336,7 +337,9 @@
    "source": [
     "# At the end of each model run, calculate the fraction of trees which are Burned Out\n",
     "model_reporter = {\n",
-    "    \"BurnedOut\": lambda m: (ForestFire.count_type(m, \"Burned Out\") / len(m.agents))\n",
+    "    \"BurnedOut\": lambda m: (\n",
+    "        ForestFire.count_type(m, \"Burned Out\") / m.schedule.get_agent_count()\n",
+    "    )\n",
     "}"
    ]
   },

--- a/examples/forest_fire/forest_fire/agent.py
+++ b/examples/forest_fire/forest_fire/agent.py
@@ -8,20 +8,17 @@ class TreeCell(mesa.Agent):
     Attributes:
         x, y: Grid coordinates
         condition: Can be "Fine", "On Fire", or "Burned Out"
-        unique_id: (x,y) tuple.
+        unique_id: int
 
-    unique_id isn't strictly necessary here, but it's good
-    practice to give one to each agent anyway.
     """
 
-    def __init__(self, unique_id, model):
+    def __init__(self, model):
         """
         Create a new tree.
         Args:
-            unique_id: Unique identifier for the agent.
             model: standard model reference for agent.
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.condition = "Fine"
 
     def step(self):

--- a/examples/forest_fire/forest_fire/model.py
+++ b/examples/forest_fire/forest_fire/model.py
@@ -33,7 +33,7 @@ class ForestFire(mesa.Model):
         for contents, (x, y) in self.grid.coord_iter():
             if self.random.random() < density:
                 # Create a tree
-                new_tree = TreeCell(self.next_id(), self)
+                new_tree = TreeCell(self)
                 # Set all trees in the first column on fire.
                 if x == 0:
                     new_tree.condition = "On Fire"

--- a/examples/hex_snowflake/hex_snowflake/cell.py
+++ b/examples/hex_snowflake/hex_snowflake/cell.py
@@ -11,7 +11,7 @@ class Cell(mesa.Agent):
         """
         Create a cell, in the given state, at the given x, y position.
         """
-        super().__init__(pos, model)
+        super().__init__(model)
         self.x, self.y = pos
         self.state = init_state
         self._nextState = None

--- a/examples/hotelling_law/hotelling_law/agents.py
+++ b/examples/hotelling_law/hotelling_law/agents.py
@@ -9,11 +9,11 @@ class StoreAgent(Agent):
     """An agent representing a store with a price and ability to move
     and adjust prices."""
 
-    def __init__(self, unique_id, model, price=10, can_move=True, strategy="Budget"):
+    def __init__(self, model, price=10, can_move=True, strategy="Budget"):
         # Initializes the store agent with a unique ID,
         # the model it belongs to,its initial price,
         # and whether it can move.
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.price = price  # Initial price of the store.
         self.can_move = can_move  # Indicates if the agent can move.
         self.market_share = 0  # Initialize market share
@@ -160,8 +160,8 @@ class ConsumerAgent(Agent):
     """A consumer agent that chooses a store
     based on price and distance."""
 
-    def __init__(self, unique_id, model):
-        super().__init__(unique_id, model)
+    def __init__(self, model):
+        super().__init__(model)
         self.preferred_store = None
 
     def determine_preferred_store(self):

--- a/examples/hotelling_law/hotelling_law/model.py
+++ b/examples/hotelling_law/hotelling_law/model.py
@@ -178,13 +178,13 @@ class HotellingModel(Model):
         )  # Calculate number of mobile agents.
         mobile_agents_assigned = 0
 
-        for unique_id in range(self.num_agents):
+        for _ in range(self.num_agents):
             strategy = random.choices(["Budget", "Premium"], weights=[70, 30], k=1)[0]
             can_move = mobile_agents_assigned < num_mobile_agents
             if can_move:
                 mobile_agents_assigned += 1
 
-            agent = StoreAgent(unique_id, self, can_move=can_move, strategy=strategy)
+            agent = StoreAgent(self, can_move=can_move, strategy=strategy)
 
             self.store_agents.add(agent)
 
@@ -194,9 +194,9 @@ class HotellingModel(Model):
             self.grid.place_agent(agent, (x, y))
 
         # Place consumer agents
-        for i in range(self.num_consumers):
+        for _ in range(self.num_consumers):
             # Ensure unique ID across all agents
-            consumer = ConsumerAgent(self.num_agents + i, self)
+            consumer = ConsumerAgent(self)
 
             self.consumer_agents.add(consumer)
             # Place consumer randomly on the grid

--- a/examples/pd_grid/pd_grid/agent.py
+++ b/examples/pd_grid/pd_grid/agent.py
@@ -4,17 +4,16 @@ import mesa
 class PDAgent(mesa.Agent):
     """Agent member of the iterated, spatial prisoner's dilemma model."""
 
-    def __init__(self, unique_id, model, starting_move=None):
+    def __init__(self, model, starting_move=None):
         """
         Create a new Prisoner's Dilemma agent.
 
         Args:
-            unique_id: Unique identifier for the agent.
             model: model instance
             starting_move: If provided, determines the agent's initial state:
                            C(ooperating) or D(efecting). Otherwise, random.
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.score = 0
         if starting_move:
             self.move = starting_move

--- a/examples/pd_grid/pd_grid/model.py
+++ b/examples/pd_grid/pd_grid/model.py
@@ -37,7 +37,7 @@ class PdGrid(mesa.Model):
         # Create agents
         for x in range(width):
             for y in range(height):
-                agent = PDAgent(self.next_id(), self)
+                agent = PDAgent(self)
                 self.grid.place_agent(agent, (x, y))
                 self.schedule.add(agent)
 

--- a/examples/schelling/model.py
+++ b/examples/schelling/model.py
@@ -6,16 +6,15 @@ class SchellingAgent(mesa.Agent):
     Schelling segregation agent
     """
 
-    def __init__(self, unique_id, model, agent_type):
+    def __init__(self, model, agent_type):
         """
         Create a new Schelling agent.
 
         Args:
-           unique_id: Unique identifier for the agent.
            x, y: Agent initial location.
            agent_type: Indicator for the agent's type (minority=1, majority=0)
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.type = agent_type
 
     def step(self):
@@ -82,7 +81,7 @@ class Schelling(mesa.Model):
         for _, pos in self.grid.coord_iter():
             if self.random.random() < self.density:
                 agent_type = 1 if self.random.random() < self.minority_pc else 0
-                agent = SchellingAgent(self.next_id(), self, agent_type)
+                agent = SchellingAgent(self, agent_type)
                 self.grid.place_agent(agent, pos)
 
         self.datacollector.collect(self)

--- a/examples/schelling_experimental/model.py
+++ b/examples/schelling_experimental/model.py
@@ -6,15 +6,14 @@ class SchellingAgent(mesa.Agent):
     Schelling segregation agent
     """
 
-    def __init__(self, unique_id, model, agent_type):
+    def __init__(self, model, agent_type):
         """
         Create a new Schelling agent.
 
         Args:
-           unique_id: Unique identifier for the agent.
            agent_type: Indicator for the agent's type (minority=1, majority=0)
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.type = agent_type
 
     def step(self):
@@ -55,7 +54,7 @@ class Schelling(mesa.Model):
         for _, pos in self.grid.coord_iter():
             if self.random.random() < density:
                 agent_type = 1 if self.random.random() < minority_pc else 0
-                agent = SchellingAgent(self.next_id(), self, agent_type)
+                agent = SchellingAgent(self, agent_type)
                 self.grid.place_agent(agent, pos)
 
         self.datacollector.collect(self)

--- a/examples/shape_example/shape_example/model.py
+++ b/examples/shape_example/shape_example/model.py
@@ -2,8 +2,8 @@ import mesa
 
 
 class Walker(mesa.Agent):
-    def __init__(self, unique_id, model, heading=(1, 0)):
-        super().__init__(unique_id, model)
+    def __init__(self, model, heading=(1, 0)):
+        super().__init__(model)
         self.heading = heading
         self.headings = {(1, 0), (0, 1), (-1, 0), (0, -1)}
 
@@ -30,7 +30,7 @@ class ShapeExample(mesa.Model):
             # heading = (1, 0)
             if self.grid.is_cell_empty(pos):
                 print(f"Creating agent {unique_id} at ({x}, {y})")
-                a = Walker(unique_id, self, heading)
+                a = Walker(self, heading)
 
                 self.grid.place_agent(a, pos)
                 unique_id += 1

--- a/examples/sugarscape_cg/sugarscape_cg/agents.py
+++ b/examples/sugarscape_cg/sugarscape_cg/agents.py
@@ -17,8 +17,8 @@ def get_distance(pos_1, pos_2):
 
 
 class SsAgent(mesa.Agent):
-    def __init__(self, unique_id, model, moore=False, sugar=0, metabolism=0, vision=0):
-        super().__init__(unique_id, model)
+    def __init__(self, model, moore=False, sugar=0, metabolism=0, vision=0):
+        super().__init__(model)
         self.moore = moore
         self.sugar = sugar
         self.metabolism = metabolism
@@ -71,8 +71,8 @@ class SsAgent(mesa.Agent):
 
 
 class Sugar(mesa.Agent):
-    def __init__(self, unique_id, model, max_sugar):
-        super().__init__(unique_id, model)
+    def __init__(self, model, max_sugar):
+        super().__init__(model)
         self.amount = max_sugar
         self.max_sugar = max_sugar
 

--- a/examples/sugarscape_cg/sugarscape_cg/model.py
+++ b/examples/sugarscape_cg/sugarscape_cg/model.py
@@ -47,11 +47,9 @@ class SugarscapeCg(mesa.Model):
         import numpy as np
 
         sugar_distribution = np.genfromtxt(Path(__file__).parent / "sugar-map.txt")
-        agent_id = 0
         for _, (x, y) in self.grid.coord_iter():
             max_sugar = sugar_distribution[x, y]
-            sugar = Sugar(agent_id, self, max_sugar)
-            agent_id += 1
+            sugar = Sugar(self, max_sugar)
             self.grid.place_agent(sugar, (x, y))
             self.schedule.add(sugar)
 
@@ -62,8 +60,7 @@ class SugarscapeCg(mesa.Model):
             sugar = self.random.randrange(6, 25)
             metabolism = self.random.randrange(2, 4)
             vision = self.random.randrange(1, 6)
-            ssa = SsAgent(agent_id, self, False, sugar, metabolism, vision)
-            agent_id += 1
+            ssa = SsAgent(self, False, sugar, metabolism, vision)
             self.grid.place_agent(ssa, (x, y))
             self.schedule.add(ssa)
 

--- a/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
+++ b/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
@@ -94,7 +94,7 @@ class SugarscapeG1mt(mesa.Model):
             resource = Resource(self, max_sugar, max_spice)
             self.grid.place_agent(resource, (x, y))
 
-        for i in range(self.initial_population):
+        for _ in range(self.initial_population):
             # get agent position
             x = self.random.randrange(self.width)
             y = self.random.randrange(self.height)

--- a/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
+++ b/examples/sugarscape_g1mt/sugarscape_g1mt/model.py
@@ -88,13 +88,11 @@ class SugarscapeG1mt(mesa.Model):
         sugar_distribution = np.genfromtxt(Path(__file__).parent / "sugar-map.txt")
         spice_distribution = np.flip(sugar_distribution, 1)
 
-        agent_id = 0
         for _, (x, y) in self.grid.coord_iter():
             max_sugar = sugar_distribution[x, y]
             max_spice = spice_distribution[x, y]
-            resource = Resource(agent_id, self, max_sugar, max_spice)
+            resource = Resource(self, max_sugar, max_spice)
             self.grid.place_agent(resource, (x, y))
-            agent_id += 1
 
         for i in range(self.initial_population):
             # get agent position
@@ -115,7 +113,6 @@ class SugarscapeG1mt(mesa.Model):
             vision = int(self.random.uniform(self.vision_min, self.vision_max + 1))
             # create Trader object
             trader = Trader(
-                agent_id,
                 self,
                 moore=False,
                 sugar=sugar,
@@ -126,7 +123,6 @@ class SugarscapeG1mt(mesa.Model):
             )
             # place agent
             self.grid.place_agent(trader, (x, y))
-            agent_id += 1
 
     def step(self):
         """

--- a/examples/sugarscape_g1mt/sugarscape_g1mt/resource_agents.py
+++ b/examples/sugarscape_g1mt/sugarscape_g1mt/resource_agents.py
@@ -9,8 +9,8 @@ class Resource(mesa.Agent):
     - grows 1 amount of spice at each turn
     """
 
-    def __init__(self, unique_id, model, max_sugar, max_spice):
-        super().__init__(unique_id, model)
+    def __init__(self, model, max_sugar, max_spice):
+        super().__init__(model)
         self.sugar_amount = max_sugar
         self.max_sugar = max_sugar
         self.spice_amount = max_spice

--- a/examples/sugarscape_g1mt/sugarscape_g1mt/trader_agents.py
+++ b/examples/sugarscape_g1mt/sugarscape_g1mt/trader_agents.py
@@ -29,7 +29,6 @@ class Trader(mesa.Agent):
 
     def __init__(
         self,
-        unique_id,
         model,
         moore=False,
         sugar=0,
@@ -38,7 +37,7 @@ class Trader(mesa.Agent):
         metabolism_spice=0,
         vision=0,
     ):
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.moore = moore
         self.sugar = sugar
         self.spice = spice

--- a/examples/virus_on_network/virus_on_network/model.py
+++ b/examples/virus_on_network/virus_on_network/model.py
@@ -65,7 +65,7 @@ class VirusOnNetwork(mesa.Model):
         )
 
         # Create agents
-        for _, node in enumerate(self.G.nodes()):
+        for node in self.G.nodes():
             a = VirusAgent(
                 self,
                 State.SUSCEPTIBLE,

--- a/examples/virus_on_network/virus_on_network/model.py
+++ b/examples/virus_on_network/virus_on_network/model.py
@@ -65,9 +65,8 @@ class VirusOnNetwork(mesa.Model):
         )
 
         # Create agents
-        for i, node in enumerate(self.G.nodes()):
+        for _, node in enumerate(self.G.nodes()):
             a = VirusAgent(
-                i,
                 self,
                 State.SUSCEPTIBLE,
                 self.virus_spread_chance,
@@ -112,7 +111,6 @@ class VirusAgent(mesa.Agent):
 
     def __init__(
         self,
-        unique_id,
         model,
         initial_state,
         virus_spread_chance,
@@ -120,7 +118,7 @@ class VirusAgent(mesa.Agent):
         recovery_chance,
         gain_resistance_chance,
     ):
-        super().__init__(unique_id, model)
+        super().__init__(model)
 
         self.state = initial_state
 

--- a/examples/wolf_sheep/wolf_sheep/agents.py
+++ b/examples/wolf_sheep/wolf_sheep/agents.py
@@ -12,8 +12,8 @@ class Sheep(RandomWalker):
 
     energy = None
 
-    def __init__(self, unique_id, model, moore, energy=None):
-        super().__init__(unique_id, model, moore=moore)
+    def __init__(self, model, moore, energy=None):
+        super().__init__(model, moore=moore)
         self.energy = energy
 
     def step(self):
@@ -44,7 +44,7 @@ class Sheep(RandomWalker):
             # Create a new sheep:
             if self.model.grass:
                 self.energy /= 2
-            lamb = Sheep(self.model.next_id(), self.model, self.moore, self.energy)
+            lamb = Sheep(self.model, self.moore, self.energy)
             self.model.grid.place_agent(lamb, self.pos)
 
 
@@ -55,8 +55,8 @@ class Wolf(RandomWalker):
 
     energy = None
 
-    def __init__(self, unique_id, model, moore, energy=None):
-        super().__init__(unique_id, model, moore=moore)
+    def __init__(self, model, moore, energy=None):
+        super().__init__(model, moore=moore)
         self.energy = energy
 
     def step(self):
@@ -83,7 +83,7 @@ class Wolf(RandomWalker):
             if self.random.random() < self.model.wolf_reproduce:
                 # Create a new wolf cub
                 self.energy /= 2
-                cub = Wolf(self.model.next_id(), self.model, self.moore, self.energy)
+                cub = Wolf(self.model, self.moore, self.energy)
                 self.model.grid.place_agent(cub, self.pos)
 
 
@@ -92,7 +92,7 @@ class GrassPatch(mesa.Agent):
     A patch of grass that grows at a fixed rate and it is eaten by sheep
     """
 
-    def __init__(self, unique_id, model, fully_grown, countdown):
+    def __init__(self, model, fully_grown, countdown):
         """
         Creates a new patch of grass
 
@@ -100,7 +100,7 @@ class GrassPatch(mesa.Agent):
             grown: (boolean) Whether the patch of grass is fully grown or not
             countdown: Time for the patch of grass to be fully grown again
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.fully_grown = fully_grown
         self.countdown = countdown
 

--- a/examples/wolf_sheep/wolf_sheep/model.py
+++ b/examples/wolf_sheep/wolf_sheep/model.py
@@ -95,7 +95,7 @@ class WolfSheep(mesa.Model):
             x = self.random.randrange(self.width)
             y = self.random.randrange(self.height)
             energy = self.random.randrange(2 * self.sheep_gain_from_food)
-            sheep = Sheep(self.next_id(), self, True, energy)
+            sheep = Sheep(self, True, energy)
             self.grid.place_agent(sheep, (x, y))
 
         # Create wolves
@@ -103,7 +103,7 @@ class WolfSheep(mesa.Model):
             x = self.random.randrange(self.width)
             y = self.random.randrange(self.height)
             energy = self.random.randrange(2 * self.wolf_gain_from_food)
-            wolf = Wolf(self.next_id(), self, True, energy)
+            wolf = Wolf(self, True, energy)
             self.grid.place_agent(wolf, (x, y))
 
         # Create grass patches
@@ -116,7 +116,7 @@ class WolfSheep(mesa.Model):
                 else:
                     countdown = self.random.randrange(self.grass_regrowth_time)
 
-                patch = GrassPatch(self.next_id(), self, fully_grown, countdown)
+                patch = GrassPatch(self, fully_grown, countdown)
                 self.grid.place_agent(patch, (x, y))
 
         self.running = True

--- a/examples/wolf_sheep/wolf_sheep/model.py
+++ b/examples/wolf_sheep/wolf_sheep/model.py
@@ -99,7 +99,7 @@ class WolfSheep(mesa.Model):
             self.grid.place_agent(sheep, (x, y))
 
         # Create wolves
-        for i in range(self.initial_wolves):
+        for _ in range(self.initial_wolves):
             x = self.random.randrange(self.width)
             y = self.random.randrange(self.height)
             energy = self.random.randrange(2 * self.wolf_gain_from_food)

--- a/examples/wolf_sheep/wolf_sheep/random_walk.py
+++ b/examples/wolf_sheep/wolf_sheep/random_walk.py
@@ -18,7 +18,7 @@ class RandomWalker(mesa.Agent):
     y = None
     moore = True
 
-    def __init__(self, unique_id, model, moore=True):
+    def __init__(self, model, moore=True):
         """
         grid: The MultiGrid object in which the agent lives.
         x: The agent's current x coordinate
@@ -26,7 +26,7 @@ class RandomWalker(mesa.Agent):
         moore: If True, may move in all 8 directions.
                 Otherwise, only up, down, left, right.
         """
-        super().__init__(unique_id, model)
+        super().__init__(model)
         self.moore = moore
 
     def random_move(self):


### PR DESCRIPTION
With [#2260](https://github.com/projectmesa/mesa/pull/2260#issue-2497065579) merged, all examples can be updated to no longer pass a unique id, nor use model.next_id. 

This only fixes the examples, not the gis-examples or rl examples. 