### PR TITLE
Use performance optimized shuffle_do() method

### DIFF
--- a/examples/aco_tsp/aco_tsp/model.py
+++ b/examples/aco_tsp/aco_tsp/model.py
@@ -225,7 +225,7 @@ class AcoTspModel(mesa.Model):
         """
         A model step. Used for activating the agents and collecting data.
         """
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         self.update_pheromone()
 
         # Check len of cities visited by an agent

--- a/examples/bank_reserves/bank_reserves/model.py
+++ b/examples/bank_reserves/bank_reserves/model.py
@@ -152,7 +152,7 @@ class BankReserves(mesa.Model):
 
     def step(self):
         # tell all the agents in the model to run their step function
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/bank_reserves/batch_run.py
+++ b/examples/bank_reserves/batch_run.py
@@ -167,7 +167,7 @@ class BankReservesModel(mesa.Model):
         # collect data
         self.datacollector.collect(self)
         # tell all the agents in the model to run their step function
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
 
     def run_model(self):
         for i in range(self.run_time):

--- a/examples/boid_flockers/boid_flockers/model.py
+++ b/examples/boid_flockers/boid_flockers/model.py
@@ -143,4 +143,4 @@ class BoidFlockers(mesa.Model):
             self.space.place_agent(boid, pos)
 
     def step(self):
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")

--- a/examples/boltzmann_wealth_model/boltzmann_wealth_model/model.py
+++ b/examples/boltzmann_wealth_model/boltzmann_wealth_model/model.py
@@ -38,7 +38,7 @@ class BoltzmannWealthModel(mesa.Model):
         self.datacollector.collect(self)
 
     def step(self):
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/boltzmann_wealth_model_experimental/model.py
+++ b/examples/boltzmann_wealth_model_experimental/model.py
@@ -38,7 +38,7 @@ class BoltzmannWealthModel(mesa.Model):
         self.datacollector.collect(self)
 
     def step(self):
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
+++ b/examples/boltzmann_wealth_model_network/boltzmann_wealth_model_network/model.py
@@ -38,7 +38,7 @@ class BoltzmannWealthModelNetwork(mesa.Model):
         self.datacollector.collect(self)
 
     def step(self):
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/caching_and_replay/model.py
+++ b/examples/caching_and_replay/model.py
@@ -93,7 +93,7 @@ class Schelling(mesa.Model):
         Run one step of the model.
         """
         self.happy = 0  # Reset counter of happy agents
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
 
         self.datacollector.collect(self)
 

--- a/examples/charts/charts/model.py
+++ b/examples/charts/charts/model.py
@@ -135,7 +135,7 @@ class Charts(mesa.Model):
 
     def step(self):
         # tell all the agents in the model to run their step function
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/el_farol/el_farol/model.py
+++ b/examples/el_farol/el_farol/model.py
@@ -34,9 +34,9 @@ class ElFarolBar(mesa.Model):
     def step(self):
         self.datacollector.collect(self)
         self.attendance = 0
-        self.agents.shuffle().do("update_attendance")
+        self.agents.shuffle_do("update_attendance")
         # We ensure that the length of history is constant
         # after each step.
         self.history.pop(0)
         self.history.append(self.attendance)
-        self.agents.shuffle().do("update_strategies")
+        self.agents.shuffle_do("update_strategies")

--- a/examples/epstein_civil_violence/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/epstein_civil_violence/model.py
@@ -105,7 +105,7 @@ class EpsteinCivilViolence(mesa.Model):
         """
         Advance the model by one step and collect data.
         """
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         # collect data
         self.datacollector.collect(self)
         self.iteration += 1

--- a/examples/forest_fire/Forest Fire Model.ipynb
+++ b/examples/forest_fire/Forest Fire Model.ipynb
@@ -149,7 +149,7 @@
     "        \"\"\"\n",
     "        Advance the model by one step.\n",
     "        \"\"\"\n",
-    "        self.agents.shuffle().do(\"step\")\n",
+    "        self.agents.shuffle_do(\"step\")\n",
     "        self.dc.collect(self)\n",
     "        # Halt if no more fire\n",
     "        if self.count_type(self, \"On Fire\") == 0:\n",

--- a/examples/forest_fire/forest_fire/model.py
+++ b/examples/forest_fire/forest_fire/model.py
@@ -46,7 +46,7 @@ class ForestFire(mesa.Model):
         """
         Advance the model by one step.
         """
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/hotelling_law/hotelling_law/model.py
+++ b/examples/hotelling_law/hotelling_law/model.py
@@ -216,7 +216,7 @@ class HotellingModel(Model):
         # Collect data for the current step.
         self.datacollector.collect(self)
         # Activate all agents in random order
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         # Update market dynamics based on the latest actions
         self.recalculate_market_share()
 

--- a/examples/schelling/model.py
+++ b/examples/schelling/model.py
@@ -91,7 +91,7 @@ class Schelling(mesa.Model):
         Run one step of the model.
         """
         self.happy = 0  # Reset counter of happy agents
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
 
         self.datacollector.collect(self)
 

--- a/examples/schelling_experimental/model.py
+++ b/examples/schelling_experimental/model.py
@@ -64,7 +64,7 @@ class Schelling(mesa.Model):
         Run one step of the model. If All agents are happy, halt the model.
         """
         self.happy = 0  # Reset counter of happy agents
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         # collect data
         self.datacollector.collect(self)
 

--- a/examples/shape_example/shape_example/model.py
+++ b/examples/shape_example/shape_example/model.py
@@ -36,4 +36,4 @@ class ShapeExample(mesa.Model):
                 unique_id += 1
 
     def step(self):
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")

--- a/examples/virus_on_network/virus_on_network/model.py
+++ b/examples/virus_on_network/virus_on_network/model.py
@@ -95,7 +95,7 @@ class VirusOnNetwork(mesa.Model):
             return math.inf
 
     def step(self):
-        self.agents.shuffle().do("step")
+        self.agents.shuffle_do("step")
         # collect data
         self.datacollector.collect(self)
 


### PR DESCRIPTION
Replace `shuffle().do()` in 18 models with the performance optimized `shuffle_do()` method.

`shuffle_do()` was added in https://github.com/projectmesa/mesa/pull/2283 and is first included in the upcoming Mesa `3.0.0a5` release. It allows for a drop-in performance upgrade:

```diff
- self.agents.shuffle().do("step")
+ self.agents.shuffle_do("step")
```
Which can speed up the Agent activation by over 3x depending on the scenario.

| Configuration                | shuffle().do() | shuffle(inplace=True).do() | shuffle_do() |
|------------------------------|----------------|----------------------------|--------------|
| 10,000 agents, 1,000 steps   | 8.27 s         | 3.65 s                     | 3.06 s       |
| 100,000 agents, 100 steps    | 13.71 s        | 6.31 s                     | 3.71 s       |
| 1,000,000 agents, 10 steps   | 18.36 s        | 9.44 s                     | 5.75 s       |

`shuffle_do()` can be used to replace the old `RandomActivation` scheduler, as demonstrated in https://github.com/projectmesa/mesa-examples/pull/183.

Part of https://github.com/projectmesa/mesa-examples/issues/111.