### PR TITLE
gis: Remove unique_id from Agent init

### DIFF
--- a/gis/agents_and_networks/src/agent/building.py
+++ b/gis/agents_and_networks/src/agent/building.py
@@ -19,8 +19,8 @@ class Building(mg.GeoAgent):
     function: float  # 1.0 for work, 2.0 for home, 0.0 for neither
     entrance_pos: mesa.space.FloatCoordinate  # nearest vertex on road
 
-    def __init__(self, unique_id, model, geometry, crs) -> None:
-        super().__init__(unique_id=unique_id, model=model, geometry=geometry, crs=crs)
+    def __init__(self, model, geometry, crs) -> None:
+        super().__init__(model=model, geometry=geometry, crs=crs)
         self.entrance = None
         self.name = str(uuid.uuid4())
         self.function = randrange(3)

--- a/gis/agents_and_networks/src/agent/commuter.py
+++ b/gis/agents_and_networks/src/agent/commuter.py
@@ -41,8 +41,8 @@ class Commuter(mg.GeoAgent):
     SPEED: float
     CHANCE_NEW_FRIEND: float  # percent chance to make a new friend every 5 min
 
-    def __init__(self, unique_id, model, geometry, crs) -> None:
-        super().__init__(unique_id, model, geometry, crs)
+    def __init__(self, model, geometry, crs) -> None:
+        super().__init__(model, geometry, crs)
         self.my_home = None
         self.start_time_h = round(np.random.normal(6.5, 1))
         while self.start_time_h < 6 or self.start_time_h > 9:

--- a/gis/agents_and_networks/src/agent/geo_agents.py
+++ b/gis/agents_and_networks/src/agent/geo_agents.py
@@ -10,8 +10,8 @@ class Driveway(mg.GeoAgent):
     geometry: Point
     crs: pyproj.CRS
 
-    def __init__(self, unique_id, model, geometry, crs) -> None:
-        super().__init__(unique_id, model, geometry, crs)
+    def __init__(self, model, geometry, crs) -> None:
+        super().__init__(model, geometry, crs)
 
 
 class LakeAndRiver(mg.GeoAgent):
@@ -20,8 +20,8 @@ class LakeAndRiver(mg.GeoAgent):
     geometry: Point
     crs: pyproj.CRS
 
-    def __init__(self, unique_id, model, geometry, crs) -> None:
-        super().__init__(unique_id, model, geometry, crs)
+    def __init__(self, model, geometry, crs) -> None:
+        super().__init__(model, geometry, crs)
 
 
 class Walkway(mg.GeoAgent):
@@ -30,5 +30,5 @@ class Walkway(mg.GeoAgent):
     geometry: Point
     crs: pyproj.CRS
 
-    def __init__(self, unique_id, model, geometry, crs) -> None:
-        super().__init__(unique_id, model, geometry, crs)
+    def __init__(self, model, geometry, crs) -> None:
+        super().__init__(model, geometry, crs)

--- a/gis/geo_schelling/model.py
+++ b/gis/geo_schelling/model.py
@@ -27,14 +27,14 @@ def get_largest_connected_components(gdf):
 class SchellingAgent(mg.GeoAgent):
     """Schelling segregation agent."""
 
-    def __init__(self, unique_id, model, geometry, crs, agent_type=None):
+    def __init__(self, model, geometry, crs, agent_type=None):
         """Create a new Schelling agent.
 
         Args:
             unique_id: Unique identifier for the agent.
             agent_type: Indicator for the agent's type (minority=1, majority=0)
         """
-        super().__init__(unique_id, model, geometry, crs)
+        super().__init__(model, geometry, crs)
         self.atype = agent_type
 
     def step(self):

--- a/gis/geo_schelling_points/geo_schelling_points/agents.py
+++ b/gis/geo_schelling_points/geo_schelling_points/agents.py
@@ -7,8 +7,8 @@ from shapely.geometry import Point
 class PersonAgent(mg.GeoAgent):
     SIMILARITY_THRESHOLD = 0.3
 
-    def __init__(self, unique_id, model, geometry, crs, is_red, region_id):
-        super().__init__(unique_id, model, geometry, crs)
+    def __init__(self, model, geometry, crs, is_red, region_id):
+        super().__init__(model, geometry, crs)
         self.is_red = is_red
         self.region_id = region_id
 
@@ -36,8 +36,8 @@ class RegionAgent(mg.GeoAgent):
     red_cnt: int
     blue_cnt: int
 
-    def __init__(self, unique_id, model, geometry, crs, init_num_people=5):
-        super().__init__(unique_id, model, geometry, crs)
+    def __init__(self, model, geometry, crs, init_num_people=5):
+        super().__init__(model, geometry, crs)
         self.init_num_people = init_num_people
         self.red_cnt = 0
         self.blue_cnt = 0

--- a/gis/geo_schelling_points/geo_schelling_points/model.py
+++ b/gis/geo_schelling_points/geo_schelling_points/model.py
@@ -1,5 +1,4 @@
 import random
-import uuid
 from pathlib import Path
 
 import mesa
@@ -34,7 +33,6 @@ class GeoSchellingPoints(mesa.Model):
         for region in regions:
             for _ in range(region.init_num_people):
                 person = PersonAgent(
-                    unique_id=uuid.uuid4().int,
                     model=self,
                     crs=self.space.crs,
                     geometry=region.random_point(),

--- a/gis/geo_sir/agents.py
+++ b/gis/geo_sir/agents.py
@@ -7,7 +7,6 @@ class PersonAgent(mg.GeoAgent):
 
     def __init__(
         self,
-        unique_id,
         model,
         geometry,
         crs,
@@ -19,14 +18,13 @@ class PersonAgent(mg.GeoAgent):
     ):
         """
         Create a new person agent.
-        :param unique_id:   Unique identifier for the agent
         :param model:       Model in which the agent runs
         :param geometry:    Shape object for the agent
         :param agent_type:  Indicator if agent is infected
                             ("infected", "susceptible", "recovered" or "dead")
         :param mobility_range:  Range of distance to move in one step
         """
-        super().__init__(unique_id, model, geometry, crs)
+        super().__init__(model, geometry, crs)
         # Agent parameters
         self.atype = agent_type
         self.mobility_range = mobility_range
@@ -84,9 +82,7 @@ class PersonAgent(mg.GeoAgent):
 class NeighbourhoodAgent(mg.GeoAgent):
     """Neighbourhood agent. Changes color according to number of infected inside it."""
 
-    def __init__(
-        self, unique_id, model, geometry, crs, agent_type="safe", hotspot_threshold=1
-    ):
+    def __init__(self, model, geometry, crs, agent_type="safe", hotspot_threshold=1):
         """
         Create a new Neighbourhood agent.
         :param unique_id:   Unique identifier for the agent
@@ -97,7 +93,7 @@ class NeighbourhoodAgent(mg.GeoAgent):
         :param hotspot_threshold:   Number of infected agents in region
                                     to be considered a hot-spot
         """
-        super().__init__(unique_id, model, geometry, crs)
+        super().__init__(model, geometry, crs)
         self.atype = agent_type
         self.hotspot_threshold = (
             hotspot_threshold  # When a neighborhood is considered a hot-spot

--- a/gis/population/population/model.py
+++ b/gis/population/population/model.py
@@ -1,6 +1,5 @@
 import math
 import random
-import uuid
 from pathlib import Path
 
 import mesa
@@ -17,8 +16,8 @@ class Person(mg.GeoAgent):
     MOBILITY_RANGE_X = 0.0
     MOBILITY_RANGE_Y = 0.0
 
-    def __init__(self, unique_id, model, geometry, crs, img_coord):
-        super().__init__(unique_id, model, geometry, crs)
+    def __init__(self, model, geometry, crs, img_coord):
+        super().__init__(model, geometry, crs)
         self.img_coord = img_coord
 
     def set_random_world_coord(self):
@@ -84,7 +83,6 @@ class Population(mesa.Model):
                     point = Point(self.space.population_layer.transform * cell.indices)
                     if not point.within(self.space.lake):
                         person = Person(
-                            unique_id=uuid.uuid4().int,
                             model=self,
                             crs=self.space.crs,
                             geometry=point,

--- a/gis/rainfall/rainfall/model.py
+++ b/gis/rainfall/rainfall/model.py
@@ -12,9 +12,8 @@ script_directory = Path(__file__).resolve().parent
 
 
 class RaindropAgent(mg.GeoAgent):
-    def __init__(self, unique_id, model, pos):
+    def __init__(self, model, pos):
         super().__init__(
-            unique_id,
             model,
             geometry=None,
             crs=model.space.crs,


### PR DESCRIPTION
Remove the `unique_id` from Agent init in the GIS models. This is now handled automatically in Mesa 3.0 (https://github.com/projectmesa/mesa/pull/2260).

Follows https://github.com/projectmesa/mesa-examples/pull/194.