### PR TITLE
gis: Remove more unique_ids

### DIFF
--- a/gis/agents_and_networks/src/model/model.py
+++ b/gis/agents_and_networks/src/model/model.py
@@ -1,4 +1,3 @@
-import uuid
 from functools import partial
 from pathlib import Path
 
@@ -137,7 +136,6 @@ class AgentsAndNetworks(mesa.Model):
             random_home = self.space.get_random_home()
             random_work = self.space.get_random_work()
             commuter = Commuter(
-                unique_id=uuid.uuid4().int,
                 model=self,
                 geometry=Point(random_home.centroid),
                 crs=self.space.crs,

--- a/gis/geo_schelling/model.py
+++ b/gis/geo_schelling/model.py
@@ -90,7 +90,7 @@ class GeoSchelling(mesa.Model):
         data_path = script_directory / "data/nuts_rg_60M_2013_lvl_2.geojson"
         agents_gdf = gpd.read_file(data_path)
         agents_gdf = get_largest_connected_components(agents_gdf)
-        agents = ac.from_GeoDataFrame(agents_gdf, unique_id="index")
+        agents = ac.from_GeoDataFrame(agents_gdf)
         self.space.add_agents(agents)
 
         # Set up agents

--- a/gis/geo_schelling_points/geo_schelling_points/model.py
+++ b/gis/geo_schelling_points/geo_schelling_points/model.py
@@ -27,7 +27,7 @@ class GeoSchellingPoints(mesa.Model):
         # Set up the grid with patches for every NUTS region
         ac = mg.AgentCreator(RegionAgent, model=self)
         data_path = script_directory / "../data/nuts_rg_60M_2013_lvl_2.geojson"
-        regions = ac.from_file(data_path, unique_id="NUTS_ID")
+        regions = ac.from_file(data_path)
         self.space.add_regions(regions)
 
         for region in regions:

--- a/gis/geo_sir/model.py
+++ b/gis/geo_sir/model.py
@@ -54,9 +54,7 @@ class GeoSir(mesa.Model):
         # Set up the Neighbourhood patches for every region in file
         # (add to schedule later)
         ac = mg.AgentCreator(NeighbourhoodAgent, model=self)
-        neighbourhood_agents = ac.from_file(
-            self.geojson_regions, unique_id=self.unique_id
-        )
+        neighbourhood_agents = ac.from_file(self.geojson_regions)
         self.space.add_agents(neighbourhood_agents)
 
         # Generate PersonAgent population

--- a/gis/population/population/space.py
+++ b/gis/population/population/space.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import gzip
-import uuid
 
 import geopandas as gpd
 import mesa
@@ -47,7 +46,7 @@ class UgandaArea(GeoSpace):
         raster_layer.total_bounds = world_size.total_bounds
         self.add_layer(raster_layer)
         self.lake = gpd.GeoDataFrame.from_file(lake_zip_file).geometry[0]
-        self.add_agents(GeoAgent(uuid.uuid4().int, model, self.lake, self.crs))
+        self.add_agents(GeoAgent(model, self.lake, self.crs))
 
     @property
     def population_layer(self):

--- a/gis/rainfall/rainfall/model.py
+++ b/gis/rainfall/rainfall/model.py
@@ -1,4 +1,3 @@
-import uuid
 from pathlib import Path
 
 import mesa
@@ -98,7 +97,6 @@ class Rainfall(mesa.Model):
             random_x = np.random.randint(0, self.space.raster_layer.width)
             random_y = np.random.randint(0, self.space.raster_layer.height)
             raindrop = RaindropAgent(
-                unique_id=uuid.uuid4().int,
                 model=self,
                 pos=(random_x, random_y),
             )


### PR DESCRIPTION
Remove more unique_ids from the Agents init in the GIS models.

Follows after the https://github.com/projectmesa/mesa-geo/pull/248

Merging directly, review still appreciated! Please take special care if unique_id in `ac.from_file`, `ac.from_GeoDataFrame` and `.add_agents` are correctly replaced. 