### PR TITLE
gis/GeoSir: Replace BaseScheduler with AgentSet functionality

### DIFF
--- a/gis/geo_sir/model.py
+++ b/gis/geo_sir/model.py
@@ -96,8 +96,9 @@ class GeoSir(mesa.Model):
         """Run one step of the model."""
         self.reset_counts()
 
-        # Activate PersonAgents first, in random order, then activate NeighbourhoodAgents.
+        # Activate PersonAgents in random order
         self.agents_by_type[PersonAgent].shuffle_do("step")
+        # For NeighbourhoodAgents the order doesn't matter, since they update independently from each other
         self.agents_by_type[NeighbourhoodAgent].do("step")
 
         self.datacollector.collect(self)

--- a/gis/geo_sir/model.py
+++ b/gis/geo_sir/model.py
@@ -29,7 +29,6 @@ class GeoSir(mesa.Model):
                                     if it has been exposed to another infected
         """
         super().__init__()
-        self.schedule = mesa.time.BaseScheduler(self)
         self.space = mg.GeoSpace(warn_crs_conversion=False)
         self.steps = 0
         self.counts = None
@@ -52,7 +51,6 @@ class GeoSir(mesa.Model):
         )
 
         # Set up the Neighbourhood patches for every region in file
-        # (add to schedule later)
         ac = mg.AgentCreator(NeighbourhoodAgent, model=self)
         neighbourhood_agents = ac.from_file(self.geojson_regions)
         self.space.add_agents(neighbourhood_agents)
@@ -64,7 +62,7 @@ class GeoSir(mesa.Model):
             crs=self.space.crs,
             agent_kwargs={"init_infected": init_infected},
         )
-        # Generate random location, add agent to grid and scheduler
+        # Generate random location and add agent to grid
         for i in range(pop_size):
             this_neighbourhood = self.random.randint(
                 0, len(neighbourhood_agents) - 1
@@ -81,12 +79,6 @@ class GeoSir(mesa.Model):
             this_y = center_y[0] + self.random.randint(0, spread_y) - spread_y / 2
             this_person = ac_population.create_agent(Point(this_x, this_y))
             self.space.add_agents(this_person)
-            self.schedule.add(this_person)
-
-        # Add the neighbourhood agents to schedule AFTER person agents,
-        # to allow them to update their color by using BaseScheduler
-        for agent in neighbourhood_agents:
-            self.schedule.add(agent)
 
         self.datacollector.collect(self)
 
@@ -102,9 +94,11 @@ class GeoSir(mesa.Model):
 
     def step(self):
         """Run one step of the model."""
-        self.steps += 1
         self.reset_counts()
-        self.schedule.step()
+
+        # Activate PersonAgents first, in random order, then activate NeighbourhoodAgents.
+        self.agents_by_type[PersonAgent].shuffle_do("step")
+        self.agents_by_type[NeighbourhoodAgent].do("step")
 
         self.datacollector.collect(self)
 


### PR DESCRIPTION
Replace BaseScheduler in the GeoSir gis model with AgentSet functionality, using `agents_by_type`, `shuffle_do()` and `do()`.

- Remove BaseScheduler initialization and usage
- Use automatic agent registration for PersonAgents
- Explicitly register NeighbourhoodAgents with the model
- Update step() method to use AgentSet methods for agent activation
- Maintain original activation order: PersonAgents (shuffled) then NeighbourhoodAgents
- Remove unnecessary scheduler.add() calls

Closes #209, follows up #207, motivated by https://github.com/projectmesa/mesa/pull/2306, similar to https://github.com/projectmesa/mesa-examples/pull/183 and https://github.com/projectmesa/mesa-examples/pull/202.

CC @glicerico.