### PR TITLE
updates examples to explicitly set ranom on new style grid spaces

### DIFF
--- a/examples/caching_and_replay/model.py
+++ b/examples/caching_and_replay/model.py
@@ -68,7 +68,7 @@ class Schelling(mesa.Model):
         self.homophily = homophily
         self.radius = radius
 
-        self.grid = OrthogonalMooreGrid((width, height), torus=True)
+        self.grid = OrthogonalMooreGrid((width, height), torus=True, random=self.random)
 
         self.happy = 0
         self.datacollector = mesa.DataCollector(

--- a/examples/charts/charts/model.py
+++ b/examples/charts/charts/model.py
@@ -101,7 +101,7 @@ class Charts(mesa.Model):
         self.width = width
         self.init_people = init_people
 
-        self.grid = OrthogonalMooreGrid((self.width, self.height), torus=True)
+        self.grid = OrthogonalMooreGrid((self.width, self.height), torus=True, random=self.random)
         # rich_threshold is the amount of savings a person needs to be considered "rich"
         self.rich_threshold = rich_threshold
         self.reserve_percent = reserve_percent

--- a/examples/color_patches/color_patches/model.py
+++ b/examples/color_patches/color_patches/model.py
@@ -67,7 +67,7 @@ class ColorPatches(mesa.Model):
         """
         super().__init__()
         self._grid = mesa.experimental.cell_space.OrthogonalMooreGrid(
-            (width, height), torus=False
+            (width, height), torus=False, random=self.random
         )
 
         # self._grid.coord_iter()

--- a/examples/forest_fire/forest_fire/model.py
+++ b/examples/forest_fire/forest_fire/model.py
@@ -21,7 +21,7 @@ class ForestFire(mesa.Model):
 
         # Set up model objects
 
-        self.grid = OrthogonalMooreGrid((width, height), capacity=1)
+        self.grid = OrthogonalMooreGrid((width, height), capacity=1, random=self.random)
         self.datacollector = mesa.DataCollector(
             {
                 "Fine": lambda m: self.count_type(m, "Fine"),

--- a/examples/hex_snowflake/hex_snowflake/model.py
+++ b/examples/hex_snowflake/hex_snowflake/model.py
@@ -10,13 +10,13 @@ class HexSnowflake(mesa.Model):
     of cells with adjacency rules specific to hexagons.
     """
 
-    def __init__(self, width=50, height=50):
+    def __init__(self, width=50, height=50, seed=None):
         """
         Create a new playing area of (width, height) cells.
         """
-        super().__init__()
+        super().__init__(seed=seed)
         # Use a hexagonal grid, where edges wrap around.
-        self.grid = HexGrid((width, height), capacity=1, torus=True)
+        self.grid = HexGrid((width, height), capacity=1, torus=True, random=self.random)
 
         # Place a dead cell at each location.
         for entry in self.grid.all_cells:

--- a/examples/hotelling_law/hotelling_law/model.py
+++ b/examples/hotelling_law/hotelling_law/model.py
@@ -97,11 +97,11 @@ class HotellingModel(Model):
         # Initialize the spatial grid based on the specified environment type.
         if environment_type == "grid":
             self.grid = OrthogonalMooreGrid(
-                (width, height), True
+                (width, height), torus=True, random=self.random
             )  # A grid where multiple agents can occupy the same cell.
         elif environment_type == "line":
             self.grid = OrthogonalMooreGrid(
-                (1, height), True
+                (1, height), torus=True, random=self.random
             )  # A grid representing a line (single occupancy per cell).
 
         self._initialize_agents()

--- a/examples/shape_example/shape_example/model.py
+++ b/examples/shape_example/shape_example/model.py
@@ -14,7 +14,7 @@ class ShapeExample(mesa.Model):
         super().__init__()
         self.N = N  # num of agents
         self.headings = ((1, 0), (0, 1), (-1, 0), (0, -1))  # tuples are fast
-        self.grid = OrthogonalMooreGrid((width, height), torus=True)
+        self.grid = OrthogonalMooreGrid((width, height), torus=True, random=self.random)
 
         self.make_walker_agents()
         self.running = True


### PR DESCRIPTION
[#2479](https://github.com/projectmesa/mesa/pull/2479) results in user warnings if random is not passed explicitly in `DiscreteSpace`, `AgentSet`, and `CellCollection`. This fixes it for the examples that did not do this correctly. 