### PR TITLE
gis: use make_geospace_component in SolaraViz

### DIFF
--- a/gis/agents_and_networks/app.py
+++ b/gis/agents_and_networks/app.py
@@ -1,7 +1,7 @@
 import sys
 
 from mesa.visualization import Slider, SolaraViz, make_plot_component
-from mesa_geo.visualization import make_geospace_leaflet
+from mesa_geo.visualization import make_geospace_component
 from src.model.model import AgentsAndNetworks
 from src.visualization.utils import agent_draw, make_plot_clock
 
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     page = SolaraViz(
         model,
         [
-            make_geospace_leaflet(agent_draw, zoom=campus_params[campus]["zoom"]),
+            make_geospace_component(agent_draw, zoom=campus_params[campus]["zoom"]),
             make_plot_clock,
             make_plot_component(["status_home", "status_work", "status_traveling"]),
             make_plot_component(["friendship_home", "friendship_work"]),

--- a/gis/agents_and_networks/requirements.txt
+++ b/gis/agents_and_networks/requirements.txt
@@ -2,7 +2,7 @@
 -e .
 
 # external requirements
-mesa-geo~=0.9.0a0
+mesa-geo~=0.9.0
 geopandas
 numpy
 pandas

--- a/gis/geo_schelling/app.py
+++ b/gis/geo_schelling/app.py
@@ -1,6 +1,6 @@
 import solara
 from mesa.visualization import Slider, SolaraViz, make_plot_component
-from mesa_geo.visualization import make_geospace_leaflet
+from mesa_geo.visualization import make_geospace_component
 from model import GeoSchelling
 
 
@@ -33,7 +33,7 @@ model = GeoSchelling()
 page = SolaraViz(
     model,
     [
-        make_geospace_leaflet(schelling_draw, zoom=4),
+        make_geospace_component(schelling_draw, zoom=4),
         make_plot_component(["happy"]),
         make_plot_happiness,
     ],

--- a/gis/geo_schelling/requirements.txt
+++ b/gis/geo_schelling/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.9.0a0
+mesa-geo~=0.9.0

--- a/gis/geo_schelling_points/app.py
+++ b/gis/geo_schelling_points/app.py
@@ -2,7 +2,7 @@ import solara
 from geo_schelling_points.agents import PersonAgent, RegionAgent
 from geo_schelling_points.model import GeoSchellingPoints
 from mesa.visualization import Slider, SolaraViz, make_plot_component
-from mesa_geo.visualization import make_geospace_leaflet
+from mesa_geo.visualization import make_geospace_component
 
 
 def make_plot_happiness(model):
@@ -35,7 +35,7 @@ model = GeoSchellingPoints()
 page = SolaraViz(
     model,
     [
-        make_geospace_leaflet(schelling_draw, zoom=4),
+        make_geospace_component(schelling_draw, zoom=4),
         make_plot_component(["happy", "unhappy"]),
         make_plot_happiness,
     ],

--- a/gis/geo_schelling_points/requirements.txt
+++ b/gis/geo_schelling_points/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.9.0a0
+mesa-geo~=0.9.0

--- a/gis/geo_sir/app.py
+++ b/gis/geo_sir/app.py
@@ -1,7 +1,7 @@
 from geo_sir.agents import PersonAgent
 from geo_sir.model import GeoSir
 from mesa.visualization import Slider, SolaraViz, make_plot_component
-from mesa_geo.visualization import make_geospace_leaflet
+from mesa_geo.visualization import make_geospace_component
 
 model_params = {
     "pop_size": Slider("Population size", 30, 10, 100, 10),
@@ -32,7 +32,7 @@ model = GeoSir()
 page = SolaraViz(
     model,
     [
-        make_geospace_leaflet(infected_draw, zoom=12),
+        make_geospace_component(infected_draw, zoom=12),
         make_plot_component(["infected", "susceptible", "recovered", "dead"]),
     ],
     name="Basic agent-based SIR model",

--- a/gis/geo_sir/requirements.txt
+++ b/gis/geo_sir/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.9.0a0
+mesa-geo~=0.9.0

--- a/gis/population/app.py
+++ b/gis/population/app.py
@@ -1,7 +1,7 @@
 import mesa_geo as mg
 import solara
 from mesa.visualization import SolaraViz
-from mesa_geo.visualization import make_geospace_leaflet
+from mesa_geo.visualization import make_geospace_component
 from population.model import Population
 from population.space import UgandaCell
 from shapely.geometry import Point, Polygon
@@ -33,7 +33,7 @@ model = Population()
 page = SolaraViz(
     model,
     [
-        make_geospace_leaflet(agent_portrayal),
+        make_geospace_component(agent_portrayal),
         make_plot_num_agents,
     ],
     name="Population Model",

--- a/gis/population/requirements.txt
+++ b/gis/population/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.9.0a1
+mesa-geo~=0.9.0

--- a/gis/rainfall/app.py
+++ b/gis/rainfall/app.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 
 from mesa.visualization import Slider, SolaraViz, make_plot_component
-from mesa_geo.visualization import make_geospace_leaflet
+from mesa_geo.visualization import make_geospace_component
 from rainfall.model import Rainfall
 from rainfall.space import LakeCell
 
@@ -32,7 +32,7 @@ model = Rainfall()
 page = SolaraViz(
     model,
     [
-        make_geospace_leaflet(cell_portrayal, zoom=11),
+        make_geospace_component(cell_portrayal, zoom=11),
         make_plot_component(
             ["Total Amount of Water", "Total Contained", "Total Outflow"]
         ),

--- a/gis/rainfall/requirements.txt
+++ b/gis/rainfall/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.9.0a1
+mesa-geo~=0.9.0

--- a/gis/urban_growth/app.py
+++ b/gis/urban_growth/app.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import solara
 from mesa.visualization import Slider, SolaraViz, make_plot_component
-from mesa_geo.visualization import make_geospace_leaflet
+from mesa_geo.visualization import make_geospace_component
 from urban_growth.model import UrbanGrowth
 from urban_growth.space import UrbanCell
 
@@ -36,7 +36,7 @@ model = UrbanGrowth()
 page = SolaraViz(
     model,
     [
-        make_geospace_leaflet(cell_portrayal, zoom=12.1),
+        make_geospace_component(cell_portrayal, zoom=12.1),
         make_plot_component(["Percentage Urbanized"]),
         make_plot_urbanized,
     ],

--- a/gis/urban_growth/requirements.txt
+++ b/gis/urban_growth/requirements.txt
@@ -1,1 +1,1 @@
-mesa-geo~=0.9.0a1
+mesa-geo~=0.9.0


### PR DESCRIPTION
For all gis examples:
- use `make_geospace_component` instead of `make_geospace_leaflet` in SolaraViz
- update Mesa-Geo dependency to v0.9.0