### PR TITLE
Sync the pre-commit config with Mesa

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,10 @@
+hist
+hart
+mutch
+ist
+inactivate
+ue
+fpr
+falsy
+assertIn
+nD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,12 @@ ci:
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.9
+  rev: v0.11.8
   hooks:
     # Run the linter.
     - id: ruff
       types_or: [ python, pyi, jupyter ]
-      args: [--fix]
+      args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
       types_or: [ python, pyi, jupyter ]


### PR DESCRIPTION
Hi!

This PR syncs the pre-commit configuration from the main Mesa repo to the Mesa examples repo.
It adds the `.codespellignore` file as well, because pre-commit depends on it, and will fail (locally) if it's not present.

This PR links to issue [2782](https://github.com/projectmesa/mesa/issues/2782) but specifically targets the first item in the list in that issue, to keep the PRs small and organized. 