### PR TITLE
fix(example): update readme for bank_transfer example

### DIFF
--- a/examples/bank_reserves/Readme.md
+++ b/examples/bank_reserves/Readme.md
@@ -22,13 +22,13 @@ To install the dependencies use pip and the requirements.txt in this directory. 
 
 ## Interactive Model Run
 
-To run the model interactively, use `mesa runserver` in this directory:
+To run the model interactively, use `solara run app.py` in this directory:
 
 ```
-    $ mesa runserver
+    $ solara run app.py
 ```
 
-Then open your browser to [http://127.0.0.1:8521/](http://127.0.0.1:8521/), select the model parameters, press Reset, then Start.
+Then open your browser to [http://localhost:8765/](http://localhost:8765/), select the model parameters, press Reset, then Start.
 
 ## Batch Run
 
@@ -43,11 +43,10 @@ To update the parameters to test other parameter sweeps, edit the list of parame
 
 ## Files
 
+* ``app.py``: Launches visualization on Solara. Customize the visualization here.
 * ``bank_reserves/random_walker.py``: This defines a class that inherits from the Mesa Agent class. The main purpose is to provide a method for agents to move randomly one cell at a time.
 * ``bank_reserves/agents.py``: Defines the People and Bank classes.
 * ``bank_reserves/model.py``: Defines the Bank Reserves model and the DataCollector functions.
-* ``bank_reserves/server.py``: Sets up the interactive visualization server.
-* ``run.py``: Launches a model visualization server.
 * ``batch_run.py``: Basically the same as model.py, but includes a Mesa BatchRunner. The result of the batch run will be a .csv file with the data from every step of every run.
 
 ## Further Reading


### PR DESCRIPTION
update the instructions to run the simulation (using Solara) and the URL to open it (using the updated port no.) 

small patch to @dlovell's fix for the `bank_reserves` example: #267.