### PR TITLE
fix: fix non-required inputs to be truly not required

### DIFF
--- a/examples/aco_tsp/aco_tsp/model.py
+++ b/examples/aco_tsp/aco_tsp/model.py
@@ -151,6 +151,10 @@ class AntTSP(CellAgent):
         self._traveled_distance = 0
 
 
+# Don't create the TSPGraph.from_random as argument default: https://docs.astral.sh/ruff/rules/function-call-in-default-argument/
+TSP_GRAPH = TSPGraph.from_random(20)
+
+
 class AcoTspModel(mesa.Model):
     """The model class holds the model-level attributes, manages the agents, and generally handles
     the global level of our model.
@@ -161,16 +165,12 @@ class AcoTspModel(mesa.Model):
 
     def __init__(
         self,
-        tsp_graph: TSPGraph | None,
         num_agents: int = 20,
         max_steps: int = int(1e6),
         ant_alpha: float = 1.0,
         ant_beta: float = 5.0,
+        tsp_graph: TSPGraph = TSP_GRAPH,
     ):
-        # Don't create the TSPGraph.from_random as argument default: https://docs.astral.sh/ruff/rules/function-call-in-default-argument/
-        if tsp_graph is None:
-            tsp_graph = TSPGraph.from_random(20)
-
         super().__init__()
         self.num_agents = num_agents
         self.tsp_graph = tsp_graph

--- a/rl/wolf_sheep/model.py
+++ b/rl/wolf_sheep/model.py
@@ -8,11 +8,13 @@ from mesa.experimental.devs import ABMSimulator
 from ray.rllib.env import MultiAgentEnv
 from utility import create_intial_agents, grid_to_observation
 
+# Don't create the ABMSimulator as argument default: https://docs.astral.sh/ruff/rules/function-call-in-default-argument/
+ABM_SIMULATOR = ABMSimulator()
+
 
 class WolfSheepRL(WolfSheep, MultiAgentEnv):
     def __init__(
         self,
-        simulator: ABMSimulator | None,
         width=20,
         height=20,
         initial_sheep=100,
@@ -25,12 +27,8 @@ class WolfSheepRL(WolfSheep, MultiAgentEnv):
         sheep_gain_from_food=4,
         seed=42,
         vision=4,
+        simulator: ABMSimulator = ABM_SIMULATOR,
     ):
-        """Create a new WolfRL-Sheep model with the given parameters."""
-        # Don't create the ABMSimulator as argument default: https://docs.astral.sh/ruff/rules/function-call-in-default-argument/
-        if simulator is None:
-            simulator = ABMSimulator()
-
         super().__init__(
             width,
             height,


### PR DESCRIPTION
When fixing Ruff findings a bug was introduces that made a couple of arguments required which is actually not needed/the case. This PR fixes the issue.