### PR TITLE
Update imports to use `mesa.discrete_space` module

### DIFF
--- a/examples/aco_tsp/aco_tsp/model.py
+++ b/examples/aco_tsp/aco_tsp/model.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import mesa
 import networkx as nx
 import numpy as np
-from mesa.experimental.cell_space import CellAgent, Network
+from mesa.discrete_space import CellAgent, Network
 
 
 @dataclass

--- a/examples/bank_reserves/bank_reserves/agents.py
+++ b/examples/bank_reserves/bank_reserves/agents.py
@@ -9,7 +9,7 @@ Author of NetLogo code:
     Northwestern University, Evanston, IL.
 """
 
-from mesa.experimental.cell_space import CellAgent
+from mesa.discrete_space import CellAgent
 
 
 class Bank:

--- a/examples/bank_reserves/bank_reserves/model.py
+++ b/examples/bank_reserves/bank_reserves/model.py
@@ -11,7 +11,7 @@ Author of NetLogo code:
 
 import mesa
 import numpy as np
-from mesa.experimental.cell_space import OrthogonalMooreGrid
+from mesa.discrete_space import OrthogonalMooreGrid
 
 from .agents import Bank, Person
 

--- a/examples/caching_and_replay/model.py
+++ b/examples/caching_and_replay/model.py
@@ -1,7 +1,7 @@
 """This file was copied over from the original Schelling mesa example."""
 
 import mesa
-from mesa.experimental.cell_space import CellAgent, OrthogonalMooreGrid
+from mesa.discrete_space import CellAgent, OrthogonalMooreGrid
 
 
 class SchellingAgent(CellAgent):

--- a/examples/charts/charts/agents.py
+++ b/examples/charts/charts/agents.py
@@ -9,7 +9,7 @@ Author of NetLogo code:
     Northwestern University, Evanston, IL.
 """
 
-from mesa.experimental.cell_space import CellAgent
+from mesa.discrete_space import CellAgent
 
 
 class Bank:

--- a/examples/charts/charts/model.py
+++ b/examples/charts/charts/model.py
@@ -11,7 +11,7 @@ Author of NetLogo code:
 
 import mesa
 import numpy as np
-from mesa.experimental.cell_space import OrthogonalMooreGrid
+from mesa.discrete_space import OrthogonalMooreGrid
 
 from .agents import Bank, Person
 

--- a/examples/forest_fire/Forest Fire Model.ipynb
+++ b/examples/forest_fire/Forest Fire Model.ipynb
@@ -78,7 +78,7 @@
    },
    "outputs": [],
    "source": [
-    "from mesa.experimental.cell_space import FixedAgent\n",
+    "from mesa.discrete_space import FixedAgent\n",
     "\n",
     "\n",
     "class TreeCell(FixedAgent):\n",
@@ -129,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mesa.experimental.cell_space import OrthogonalMooreGrid\n",
+    "from mesa.discrete_space import OrthogonalMooreGrid\n",
     "\n",
     "\n",
     "class ForestFire(Model):\n",

--- a/examples/forest_fire/forest_fire/agent.py
+++ b/examples/forest_fire/forest_fire/agent.py
@@ -1,4 +1,4 @@
-from mesa.experimental.cell_space import FixedAgent
+from mesa.discrete_space import FixedAgent
 
 
 class TreeCell(FixedAgent):

--- a/examples/forest_fire/forest_fire/model.py
+++ b/examples/forest_fire/forest_fire/model.py
@@ -1,5 +1,5 @@
 import mesa
-from mesa.experimental.cell_space import OrthogonalMooreGrid
+from mesa.discrete_space import OrthogonalMooreGrid
 
 from .agent import TreeCell
 

--- a/examples/hex_snowflake/hex_snowflake/cell.py
+++ b/examples/hex_snowflake/hex_snowflake/cell.py
@@ -1,4 +1,4 @@
-from mesa.experimental.cell_space import FixedAgent
+from mesa.discrete_space import FixedAgent
 
 
 class Cell(FixedAgent):

--- a/examples/hex_snowflake/hex_snowflake/model.py
+++ b/examples/hex_snowflake/hex_snowflake/model.py
@@ -1,5 +1,5 @@
 import mesa
-from mesa.experimental.cell_space import HexGrid
+from mesa.discrete_space import HexGrid
 
 from .cell import Cell
 

--- a/examples/hotelling_law/hotelling_law/agents.py
+++ b/examples/hotelling_law/hotelling_law/agents.py
@@ -2,7 +2,7 @@ import math
 import random
 
 import numpy as np
-from mesa.experimental.cell_space import CellAgent
+from mesa.discrete_space import CellAgent
 
 
 class StoreAgent(CellAgent):

--- a/examples/hotelling_law/hotelling_law/model.py
+++ b/examples/hotelling_law/hotelling_law/model.py
@@ -3,7 +3,7 @@ import random
 import numpy as np
 from mesa import Model
 from mesa.datacollection import DataCollector
-from mesa.experimental.cell_space import OrthogonalMooreGrid
+from mesa.discrete_space import OrthogonalMooreGrid
 
 from .agents import ConsumerAgent, StoreAgent
 

--- a/examples/shape_example/shape_example/model.py
+++ b/examples/shape_example/shape_example/model.py
@@ -1,5 +1,5 @@
 import mesa
-from mesa.experimental.cell_space import OrthogonalMooreGrid
+from mesa.discrete_space import OrthogonalMooreGrid
 
 
 class Walker(mesa.Agent):

--- a/examples/termites/termites/agents.py
+++ b/examples/termites/termites/agents.py
@@ -1,4 +1,4 @@
-from mesa.experimental.cell_space import CellAgent
+from mesa.discrete_space import CellAgent
 
 
 class Termite(CellAgent):

--- a/examples/termites/termites/model.py
+++ b/examples/termites/termites/model.py
@@ -1,5 +1,5 @@
 from mesa import Model
-from mesa.experimental.cell_space import OrthogonalMooreGrid, PropertyLayer
+from mesa.discrete_space import OrthogonalMooreGrid, PropertyLayer
 
 from .agents import Termite
 


### PR DESCRIPTION
Replaced imports from `mesa.experimental.cell_space` with `mesa.discrete_space` across multiple example models and agents.

This follows the stabilization of the discrete spaces: https://github.com/projectmesa/mesa/pull/2610. This makes all the examples require Mesa 3.2 or above.
