### PR TITLE
Fix NoneType position error in Hotelling’s Law SpaceDrawer

### DIFF
--- a/examples/hotelling_law/app.py
+++ b/examples/hotelling_law/app.py
@@ -127,6 +127,8 @@ def SpaceDrawer(model):
 
         # Track store agents for cell coloring
         if isinstance(agent, StoreAgent):
+            if agent.pos is None:
+                continue
             if agent.pos not in cell_store_contents:
                 cell_store_contents[agent.pos] = []
             cell_store_contents[agent.pos].append(portrayal)
@@ -152,6 +154,8 @@ def SpaceDrawer(model):
 
     # Jittered scatter plot for all agents
     for agent in model.agents:
+        if agent.pos is None:
+            continue
         portrayal = agent_portrayal(agent)
         jitter_x = np.random.uniform(-jitter_amount, jitter_amount) + agent.pos[0] + 0.5
         jitter_y = np.random.uniform(-jitter_amount, jitter_amount) + agent.pos[1] + 0.5


### PR DESCRIPTION
Summary

This PR fixes a TypeError in the Hotelling’s Law example that caused the visualization to crash whenever an agent didn’t have a valid grid position.

Bug / Issue

In examples/hotelling_law/app.py, the SpaceDrawer component assumes that agent.pos is always a tuple like (x, y).
However, starting with Mesa 3.2, agents can temporarily have pos = None when they're not placed on the grid.

When the code tried to access pos[0], it resulted in:

TypeError: 'NoneType' object is not subscriptable

Fix

I updated SpaceDrawer to safely handle agents whose positions are None:

- Added a simple if agent.pos is None: continue in the loop that builds the cell contents for store agents.

- Added the same check in the loop that draws the scatter plot.

With these guards, agents without positions are skipped during rendering, preventing the crash.

Testing

- Manual testing: Confirmed that solara run app.py now runs without errors and the visualization loads correctly.

- Automated testing: Ran pytest test_examples.py locally. All 15 tests passed, so the underlying model behavior remains unchanged.

Additional Notes

This update only adjusts the visualization logic to match Mesa 3.2+ behavior regarding pos=None.
No changes were made to the simulation itself.