### PR TITLE
Remove outdated PieChartModule from Forest Fire visualization

### DIFF
--- a/examples/forest_fire/app.py
+++ b/examples/forest_fire/app.py
@@ -41,11 +41,7 @@ lineplot_component = make_plot_component(
     COLORS,
     post_process=post_process_lines,
 )
-# TODO: add back in pie chart component
-# # no current pie chart equivalent in mesa>=3.0
-# pie_chart = mesa.visualization.PieChartModule(
-#     [{"Label": label, "Color": color} for (label, color) in COLORS.items()]
-# )
+
 model = ForestFire()
 model_params = {
     "height": 100,


### PR DESCRIPTION
## What this PR does
- Removes outdated `PieChartModule` references from the Forest Fire example.
- Aligns the visualization code with Mesa >= 3.0, where `PieChartModule` is no longer supported.

## Why this change
- The existing commented code references deprecated visualization APIs.
- Cleaning this up avoids confusion for new contributors and users running Mesa 3.x.

## Related issue
- Fixes #154 (Remove or update outdated visualization from examples)

## Testing
- Ran `forest_fire/app.py` locally using Solara visualization.
- Model runs successfully without visualization errors.
