### PR TITLE
Update Termites and Warehouse examples to use `rng` parameter

### DIFF
--- a/examples/termites/app.py
+++ b/examples/termites/app.py
@@ -22,10 +22,10 @@ def agent_portrayal(agent):
 
 
 model_params = {
-    "seed": {
+    "rng": {
         "type": "InputText",
         "value": 42,
-        "label": "Seed",
+        "label": "rng",
     },
     "num_termites": {
         "type": "SliderInt",

--- a/examples/termites/termites/model.py
+++ b/examples/termites/termites/model.py
@@ -8,7 +8,7 @@ class TermiteModel(Model):
     """A simulation that shows behavior of termite agents gathering wood chips into piles."""
 
     def __init__(
-        self, num_termites=100, width=100, height=100, wood_chip_density=0.1, seed=42
+        self, num_termites=100, width=100, height=100, wood_chip_density=0.1, rng=42
     ):
         """Initialize the model.
 
@@ -17,9 +17,9 @@ class TermiteModel(Model):
             width: Grid width.
             height: Grid heights.
             wood_chip_density: Density of wood chips in the grid.
-            seed : Random seed for reproducibility.
+            rng : Random number generator for reproducibility.
         """
-        super().__init__(seed=seed)
+        super().__init__(rng=42)
         self.num_termites = num_termites
         self.wood_chip_density = wood_chip_density
 

--- a/examples/warehouse/app.py
+++ b/examples/warehouse/app.py
@@ -11,10 +11,10 @@ LOADING_DOCKS = [(0, 0, 0), (0, 2, 0), (0, 4, 0), (0, 6, 0), (0, 8, 0)]
 AXIS_LIMITS = {"x": (0, 22), "y": (0, 20), "z": (0, 5)}
 
 model_params = {
-    "seed": {
+    "rng": {
         "type": "InputText",
         "value": 42,
-        "label": "Random Seed",
+        "label": "Random number generator",
     },
 }
 

--- a/examples/warehouse/warehouse/model.py
+++ b/examples/warehouse/warehouse/model.py
@@ -29,13 +29,13 @@ class WarehouseModel(mesa.Model):
     (e.g., routing, sensors, etc.).
     """
 
-    def __init__(self, seed=42):
+    def __init__(self, rng=42):
         """Initialize the model.
 
         Args:
-            seed (int): Random seed.
+            rng (int): Random number generator.
         """
-        super().__init__(seed=seed)
+        super().__init__(rng=rng)
         self.inventory = {}
         self.loading_docks = LOADING_DOCKS
         self.charging_stations = CHARGING_STATIONS


### PR DESCRIPTION
Update the Termites and Warehouse example models to use the `rng` parameter instead of the deprecated `seed` parameter, aligning with Mesa's SPEC-7 compliance and the deprecation introduced in https://github.com/mesa/mesa/pull/3147.
