### PR TITLE
fix gis examples by passing solaraviz components as keyword argument

### DIFF
--- a/gis/agents_and_networks/app.py
+++ b/gis/agents_and_networks/app.py
@@ -53,14 +53,14 @@ if __name__ == "__main__":
     model = AgentsAndNetworks()
     page = SolaraViz(
         model,
-        [
+        name="Agents and Networks",
+        model_params=model_params,
+        components=[
             make_geospace_component(agent_draw, zoom=campus_params[campus]["zoom"]),
             make_plot_clock,
             make_plot_component(["status_home", "status_work", "status_traveling"]),
             make_plot_component(["friendship_home", "friendship_work"]),
         ],
-        name="Agents and Networks",
-        model_params=model_params,
     )
 
     page  # noqa

--- a/gis/geo_schelling/app.py
+++ b/gis/geo_schelling/app.py
@@ -30,13 +30,13 @@ def schelling_draw(agent):
 model = GeoSchelling()
 page = SolaraViz(
     model,
-    [
+    name="GeoSchelling",
+    model_params=model_params,
+    components=[
         make_geospace_component(schelling_draw, zoom=4),
         make_plot_component(["happy"]),
         make_plot_happiness,
     ],
-    model_params=model_params,
-    name="GeoSchelling",
 )
 
 page  # noqa

--- a/gis/geo_schelling_points/app.py
+++ b/gis/geo_schelling_points/app.py
@@ -34,13 +34,13 @@ def schelling_draw(agent):
 model = GeoSchellingPoints()
 page = SolaraViz(
     model,
-    [
+    name="GeoSchellingPoints",
+    model_params=model_params,
+    components=[
         make_geospace_component(schelling_draw, zoom=4),
         make_plot_component(["happy", "unhappy"]),
         make_plot_happiness,
     ],
-    model_params=model_params,
-    name="GeoSchellingPoints",
 )
 
 page  # noqa

--- a/gis/geo_sir/app.py
+++ b/gis/geo_sir/app.py
@@ -29,12 +29,12 @@ def infected_draw(agent):
 model = GeoSir()
 page = SolaraViz(
     model,
-    [
+    name="Basic agent-based SIR model",
+    model_params=model_params,
+    components=[
         make_geospace_component(infected_draw, zoom=12),
         make_plot_component(["infected", "susceptible", "recovered", "dead"]),
     ],
-    name="Basic agent-based SIR model",
-    model_params=model_params,
 )
 
 page  # noqa

--- a/gis/population/app.py
+++ b/gis/population/app.py
@@ -32,11 +32,11 @@ def agent_portrayal(agent):
 model = Population()
 page = SolaraViz(
     model,
-    [
+    name="Population Model",
+    components=[
         make_geospace_component(agent_portrayal),
         make_plot_num_agents,
     ],
-    name="Population Model",
 )
 
 page  # noqa

--- a/gis/rainfall/app.py
+++ b/gis/rainfall/app.py
@@ -29,14 +29,14 @@ def cell_portrayal(cell: LakeCell) -> tuple[float, float, float, float]:
 model = Rainfall()
 page = SolaraViz(
     model,
-    [
+    name="Rainfall Model",
+    model_params=model_params,
+    components=[
         make_geospace_component(cell_portrayal, zoom=11),
         make_plot_component(
             ["Total Amount of Water", "Total Contained", "Total Outflow"]
         ),
     ],
-    name="Rainfall Model",
-    model_params=model_params,
 )
 
 page  # noqa

--- a/gis/urban_growth/app.py
+++ b/gis/urban_growth/app.py
@@ -33,13 +33,13 @@ model_params = {
 model = UrbanGrowth()
 page = SolaraViz(
     model,
-    [
+    name="Urban Growth Model",
+    model_params=model_params,
+    components=[
         make_geospace_component(cell_portrayal, zoom=12.1),
         make_plot_component(["Percentage Urbanized"]),
         make_plot_urbanized,
     ],
-    name="Urban Growth Model",
-    model_params=model_params,
 )
 
 page  # noqa


### PR DESCRIPTION
This is a temporary workaround for https://github.com/mesa/mesa-geo/issues/295, by changing `components` from positional argument to keyword argument in all GIS examples. For example:

from

```python
page = SolaraViz(
    model,
    [
        make_geospace_component(schelling_draw, zoom=4),
    ]
)
```

to

```python
page = SolaraViz(
    model,
    components=[
        make_geospace_component(schelling_draw, zoom=4),
    ],
)
```

For Mesa-Geo I'll remove the pin to Mesa<3.3 dependency and note the workaround. But I'll keep https://github.com/mesa/mesa-geo/issues/295 open until we have a better visualization API for Mesa-Geo.