### PR TITLE
Add Wind-Driven Forest Fire example

### DIFF
--- a/examples/forest_fire/app.py
+++ b/examples/forest_fire/app.py
@@ -47,14 +47,15 @@ model_params = {
     "height": 100,
     "width": 100,
     "density": Slider("Tree density", 0.65, 0.01, 1.0, 0.01),
-
-    "use_prob": {"type": "Checkbox", "label": "Use probabilistic spread", "value": False},
+    "use_prob": {
+        "type": "Checkbox",
+        "label": "Use probabilistic spread",
+        "value": False,
+    },
     "p_spread": Slider("Base spread probability", 0.5, 0.0, 1.0, 0.01),
-
     "wind_enabled": {"type": "Checkbox", "label": "Enable wind bias", "value": False},
     "wind_dir": Slider("Wind direction (deg)", 0, 0, 360, 1),
     "wind_strength": Slider("Wind strength", 1.0, 0.0, 2.0, 0.05),
-
 }
 page = SolaraViz(
     model,

--- a/examples/forest_fire/forest_fire/agent.py
+++ b/examples/forest_fire/forest_fire/agent.py
@@ -36,7 +36,10 @@ class TreeCell(FixedAgent):
                 dy = neighbor.cell.coordinate[1] - self.cell.coordinate[1]
 
                 factor = 1.0
-                if getattr(self.model, "wind_enabled", False) and getattr(self.model, "wind_strength", 0.0) > 0:
+                if (
+                    getattr(self.model, "wind_enabled", False)
+                    and getattr(self.model, "wind_strength", 0.0) > 0
+                ):
                     factor = self.model.wind_biased_multiplier(dx, dy)
 
                 p = self.model.p_spread * factor

--- a/examples/forest_fire/forest_fire/model.py
+++ b/examples/forest_fire/forest_fire/model.py
@@ -1,15 +1,26 @@
+import math
+
 import mesa
 from mesa.discrete_space import OrthogonalMooreGrid
-import math
+
 from .agent import TreeCell
 
 
 class ForestFire(mesa.Model):
     """Simple Forest Fire model."""
 
-    def __init__(self, width=100, height=100, density=0.65, seed=None,
-                 use_prob=False, p_spread=0.5,
-                 wind_enabled=False, wind_dir=0.0, wind_strength=1.0):
+    def __init__(
+        self,
+        width=100,
+        height=100,
+        density=0.65,
+        seed=None,
+        use_prob=False,
+        p_spread=0.5,
+        wind_enabled=False,
+        wind_dir=0.0,
+        wind_strength=1.0,
+    ):
         """Create a new forest fire model.
 
         Args:
@@ -48,7 +59,7 @@ class ForestFire(mesa.Model):
         self.datacollector.collect(self)
 
     def ignite_initial_fire(self):
-            # wind bias on: central ignitian
+        # wind bias on: central ignitian
 
         if getattr(self, "wind_enabled", False):
             cx = self.width // 2
@@ -79,7 +90,7 @@ class ForestFire(mesa.Model):
     def count_type(model, tree_condition):
         """Helper method to count trees in a given condition in a given model."""
         return len(model.agents.select(lambda x: x.condition == tree_condition))
-    
+
     # Wind Mechanisum
 
     def wind_unit_vector(self):
@@ -101,4 +112,3 @@ class ForestFire(mesa.Model):
         dxu, dyu = dx / norm, dy / norm
         align = dxu * wx + dyu * wy  # [-1, 1]
         return max(0.0, 1.0 + (self.wind_strength * align))
-

--- a/examples/forest_fire/wind_extended.md
+++ b/examples/forest_fire/wind_extended.md
@@ -1,7 +1,7 @@
 # Forest Fire Model Extended with Optional Wind Bias
 This implementation extends the original Mesa Forest Fire model by adding an optional wind-driven fire spread mechanism, while preserving the original deterministic behavior as the default mode.
 
-### New Features 
+### New Features
 This extended version introduces an optional wind bias module with the following capabilities:
 
 1. **default behavior**


### PR DESCRIPTION
### Summary
This PR adds a new model example: **Wind-Driven Forest Fire**.

Compared to forest fire model which focuses on critical thresholds, this model introduces **anisotropy** caused by wind. It demonstrates how to implement directional bias in grid-based models and explicitly measures the Rate of Spread (ROS) for both the fire head (downwind) and the flank (crosswind).

### Motive
**Modeling Anisotropy**
The model implements a wind-biased ignition probability formula based on the angle between the wind vector and the neighbor direction:
$$p = p_{\text{spread}} \cdot (1 + \text{strength} \cdot \cos(\theta))$$

### Implementation
Instead of just counting "burned trees," this model calculates spatial metrics:
- **Head Distance:** The furthest distance the fire has traveled downwind.
- **Flank Width:** The lateral width of the fire scar perpendicular to the wind.
- **ROS (Rate of Spread):** Real-time calculation of the fire front's speed.

### Usage Examples
<img width="1883" height="670" alt="strong wind" src="https://github.com/user-attachments/assets/039ba613-0e03-4cc2-b02c-e607e1ecc71b" />


### Additional Notes
<!-- Add any additional information that may be relevant for the reviewers, such as potential side effects, dependencies, or related work. -->
