### PR TITLE
CI: Exempt PendingDeprecationWarning from warnings-as-errors

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -27,7 +27,7 @@ jobs:
   #   - name: Install dependencies
   #     run: pip install mesa[network] pytest
   #   - name: Test with pytest
-  #     run: pytest -rA -Werror test_examples.py
+  #     run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_examples.py
 
   build-pre:
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
         pip install mesa[network] --pre
         pip install .[test]
     - name: Test with pytest
-      run: pytest -rA -Werror -Wdefault::FutureWarning test_examples.py
+      run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_examples.py
 
   build-main:
     runs-on: ubuntu-latest
@@ -57,4 +57,4 @@ jobs:
         pip install .[test]
         pip install -U git+https://github.com/mesa/mesa@main#egg=mesa[network]
     - name: Test with pytest
-      run: pytest -rA -Werror -Wdefault::FutureWarning test_examples.py
+      run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_examples.py

--- a/.github/workflows/test_gis_examples.yml
+++ b/.github/workflows/test_gis_examples.yml
@@ -27,7 +27,7 @@ jobs:
   #   - name: Install dependencies
   #     run: pip install mesa pytest
   #   - name: Test with pytest
-  #     run: pytest -rA -Werror test_examples.py
+  #     run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_examples.py
 
   build-pre:
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
         pip install mesa-geo --pre
         pip install .[test_gis]
     - name: Test with pytest
-      run: pytest -rA -Werror test_gis_examples.py
+      run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_gis_examples.py
 
   build-main:
     runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
         pip install -U git+https://github.com/mesa/mesa-geo@main#egg=mesa-geo
         pip install .[test_gis]
     - name: Test with pytest
-      run: pytest -rA -Werror test_gis_examples.py --cov-report=xml
+      run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_gis_examples.py --cov-report=xml
     - name: Codecov
       uses: codecov/codecov-action@v5
       with:


### PR DESCRIPTION
Mesa recently updated its CI to treat warnings as errors while explicitly exempting `PendingDeprecationWarning` per the deprecation policy. This PR mirrors that behavior in mesa-examples.

All warnings except `PendingDeprecationWarning` continue to fail CI, preventing warning accumulation and catching issues early, while now allowing pending deprecations to surface as regular warnings without breaking example builds.

See https://github.com/mesa/mesa/pull/2926