### PR TITLE
fix: Add rng parameter to BankReservesModel

### DIFF
--- a/examples/bank_reserves/bank_reserves/model.py
+++ b/examples/bank_reserves/bank_reserves/model.py
@@ -105,8 +105,9 @@ class BankReservesModel(mesa.Model):
         init_people=2,
         rich_threshold=10,
         reserve_percent=50,
+        rng=None,
     ):
-        super().__init__()
+        super().__init__(rng=rng)
         self.height = height
         self.width = width
         self.init_people = init_people


### PR DESCRIPTION
## Description
Fixes #316 

This PR adds the missing `rng` parameter to `BankReservesModel.__init__()` to make it compatible with `mesa.batch_run()`.

## Changes
- Added `rng=None` parameter to `BankReservesModel.__init__()`
- Pass `rng` to `super().__init__(rng=rng)` for proper RNG initialization
- Aligns with the pattern used in other examples (forest_fire, hotelling_law, hex_snowflake)

## Testing

- [x] Verified `batch_run.py` executes successfully without errors
- [x] Generates correct CSV output with all parameter combinations
- [x] Backward compatible with interactive visualization (`solara run app.py`)

## Context
This completes the Mesa 3.x migration for bank_reserves that was started in #267, which updated the visualization but missed the RNG parameter update. 

Since bank_reserves is currently the **only example with a batch_run.py file**, this fix is particularly important for demonstrating Mesa's batch_run functionality to users.

## Code Changes 

**Before** 
```python
def __init__(self, height=..., width=..., init_people=..., 
             rich_threshold=..., reserve_percent=...):
    super().__init__()  # Missing rng parameter
```
**After**
```python 
def __init__(self, height=..., width=..., init_people=..., 
             rich_threshold=..., reserve_percent=..., rng=None):
    super().__init__(rng=rng)   # Properly passes rng to parent
```

## Related
- Closes #316
- Related to #267 (Mesa 3.x migration)