### PR TITLE
fix: update examples for AgentSet API

### DIFF
--- a/examples/deffuant_weisbuch/deffuant_weisbuch/model.py
+++ b/examples/deffuant_weisbuch/deffuant_weisbuch/model.py
@@ -58,7 +58,7 @@ class DeffuantWeisbuchModel(Model):
         less than the confidence threshold, both agents update opinion values
         symmetrically.
         """
-        agent_list = self.agents.to_list()
+        agent_list = list(self.agents)
         for _ in range(self.n):
             agent_a, agent_b = self.random.sample(agent_list, 2)
             self.attempted_interactions += 1

--- a/examples/warehouse/warehouse/model.py
+++ b/examples/warehouse/warehouse/model.py
@@ -95,7 +95,7 @@ class WarehouseModel(mesa.Model):
     def step(self):
         """Advance the model by one step."""
         for robot in self.agents_by_type[type(self.RobotAgent)]:
-            agent_list = self.agents_by_type[InventoryAgent].to_list()
+            agent_list = list(self.agents_by_type[InventoryAgent])
 
             if robot.status == "open":  # Assign a task to the robot
                 item = self.random.choice(agent_list)


### PR DESCRIPTION
### Fix

This PR updates the Deffuant–Weisbuch and Warehouse examples to replace the deprecated AgentSet.to_list() call with list(...), which was causing these examples to fail in CI.

Thanks!