### PR TITLE
Remove unused deprecated ABMSimulator from virus_antibody example

### DIFF
--- a/examples/virus_antibody/app.py
+++ b/examples/virus_antibody/app.py
@@ -1,7 +1,6 @@
 import weakref
 
 from matplotlib.markers import MarkerStyle
-from mesa.experimental.devs import ABMSimulator
 from mesa.visualization import (
     Slider,
     SolaraViz,
@@ -56,7 +55,6 @@ def agent_portrayal(agent):
 
 
 # Setup model parameters for the visualization interface
-simulator = ABMSimulator()
 model = VirusAntibodyModel()
 
 model_params = {


### PR DESCRIPTION
While testing mesa-examples with the latest Mesa version, I noticed that
the virus_antibody example imports and instantiates ABMSimulator from
mesa.experimental.devs.

Mesa currently emits a FutureWarning indicating that ABMSimulator is
deprecated and will be removed in a future release.

In this example, the simulator object does not appear to be used
elsewhere in the file. I removed the unused import and instantiation.

After this change:

- The example launches normally
- The simulation runs as expected
- The ABMSimulator deprecation warning disappears

This is a small cleanup to help keep the example compatible with future
Mesa releases.