### PR TITLE
pyproject: sync with mesa/mesa and ensure tests run against GitHub repo

### DIFF
--- a/gis/agents_and_networks/src/space/campus.py
+++ b/gis/agents_and_networks/src/space/campus.py
@@ -1,6 +1,5 @@
 import random
 from collections import defaultdict
-from typing import DefaultDict
 
 import mesa_geo as mg
 from shapely.geometry import Point
@@ -15,9 +14,9 @@ class Campus(mg.GeoSpace):
     homes: tuple[Building]
     works: tuple[Building]
     other_buildings: tuple[Building]
-    home_counter: DefaultDict[FloatCoordinate, int]
+    home_counter: defaultdict[FloatCoordinate, int]
     _buildings: dict[int, Building]
-    _commuters_pos_map: DefaultDict[FloatCoordinate, set[Commuter]]
+    _commuters_pos_map: defaultdict[FloatCoordinate, set[Commuter]]
     _commuter_id_map: dict[int, Commuter]
 
     def __init__(self, crs: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ extend-ignore = [
   "PGH004", # Use specific rule codes when using `noqa` TODO
   "B905",   # `zip()` without an explicit `strict=` parameter
   "N802",   # Function name should be lowercase
-  "N999",   # Invalid module name. We should revisit this in the future, TODO  
+  "N999",   # Invalid module name. We should revisit this in the future, TODO
   "S310",   # Audit URL open for permitted schemes. Allowing use of `file:` or custom schemes is often unexpected.
   "S603",   # `subprocess` call: check for execution of untrusted input
   "ISC001", # ruff format asks to disable this feature


### PR DESCRIPTION
Closes https://github.com/mesa/mesa/issues/2782 (pyproject sync checklist item)

Changes:
- Add `allow-direct-references = true` for hatchling
- Sync ruff target-version to py312
- Add codespell section
- Add extend-exclude = ["build"] to ruff
- Install mesa from GitHub main in all test dependency groups

