### PR TITLE
ci: add codecov coverage reporting and pytest-cov dependency

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -57,4 +57,10 @@ jobs:
         pip install .[test]
         pip install -U "mesa[network] @ git+https://github.com/mesa/mesa@main"
     - name: Test with pytest
-      run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_examples.py
+      run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning --cov=examples --cov-report=xml --cov-report=term test_examples.py
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: ./coverage.xml
+        fail_ci_if_error: false
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ readme = "README.md"
 test = [
     "pytest",
     "scipy",
+    "pytest-cov",
 ]
 test_gis = [
     "pytest",


### PR DESCRIPTION
Part of https://github.com/mesa/mesa/issues/2782 — adds codecov coverage

Changes:
- Add `pytest-cov` to test dependencies in pyproject.toml
- Add `--cov=examples --cov-report=xml` flags to pytest run in build-main job
- Add `codecov/codecov-action@v4` step to upload coverage results to Codecov

Coverage is only tracked in `build-main` (against Mesa GitHub main) since that is the stable reference point. 