### PR TITLE
fix: use absolute path for aco_tsp data file

### DIFF
--- a/examples/aco_tsp/app.py
+++ b/examples/aco_tsp/app.py
@@ -11,7 +11,6 @@ from mesa.visualization import SolaraViz, make_plot_component
 def circle_portrayal_example(agent):
     return {"node_size": 20, "width": 0.1}
 
-
 tsp_graph = TSPGraph.from_tsp_file(os.path.join(os.path.dirname(__file__), "aco_tsp/data/kroA100.tsp"))
 model_params = {
     "num_agents": tsp_graph.num_cities,

--- a/examples/aco_tsp/app.py
+++ b/examples/aco_tsp/app.py
@@ -1,8 +1,9 @@
 """Configure visualization elements and instantiate a server"""
 
+import os
+
 import networkx as nx
 import solara
-import os
 from aco_tsp.model import AcoTspModel, TSPGraph
 from matplotlib.figure import Figure
 from mesa.visualization import SolaraViz, make_plot_component
@@ -12,7 +13,9 @@ def circle_portrayal_example(agent):
     return {"node_size": 20, "width": 0.1}
 
 
-tsp_graph = TSPGraph.from_tsp_file(os.path.join(os.path.dirname(__file__), "aco_tsp/data/kroA100.tsp"))
+tsp_graph = TSPGraph.from_tsp_file(
+    os.path.join(os.path.dirname(__file__), "aco_tsp/data/kroA100.tsp")
+)
 model_params = {
     "num_agents": tsp_graph.num_cities,
     "tsp_graph": tsp_graph,

--- a/examples/aco_tsp/app.py
+++ b/examples/aco_tsp/app.py
@@ -1,5 +1,7 @@
 """Configure visualization elements and instantiate a server"""
+
 import os
+
 import networkx as nx
 import solara
 from aco_tsp.model import AcoTspModel, TSPGraph

--- a/examples/aco_tsp/app.py
+++ b/examples/aco_tsp/app.py
@@ -2,6 +2,7 @@
 
 import networkx as nx
 import solara
+import os
 from aco_tsp.model import AcoTspModel, TSPGraph
 from matplotlib.figure import Figure
 from mesa.visualization import SolaraViz, make_plot_component
@@ -11,7 +12,7 @@ def circle_portrayal_example(agent):
     return {"node_size": 20, "width": 0.1}
 
 
-tsp_graph = TSPGraph.from_tsp_file("aco_tsp/data/kroA100.tsp")
+tsp_graph = TSPGraph.from_tsp_file(os.path.join(os.path.dirname(__file__), "aco_tsp/data/kroA100.tsp"))
 model_params = {
     "num_agents": tsp_graph.num_cities,
     "tsp_graph": tsp_graph,


### PR DESCRIPTION
Thanks for opening a PR! Please click the `Preview` tab and select a PR template:

- [🐛 Bug fix](?expand=1&template=bug.md)
- [🛠 Feature/enhancement](?expand=1&template=feature.md)

Problem: The aco_tsp example fails with FileNotFoundError when run from the repo root directory because the data file path is relative.
Fix: Used os.path.dirname(__file__) to make the path absolute, so it works regardless of where the script is run from.
Fixes the error: FileNotFoundError: No such file or directory: 'aco_tsp/data/kroA100.tsp'

---

## GSoC contributor checklist

### Context & motivation
I found this bug while testing mesa-examples locally. When running the aco_tsp example from the repo root, it throws a FileNotFoundError because the data file path is relative to the working directory, not the script location. This is a real usability issue for anyone trying to run the examples.

### What I learned
I learned that file paths in Python scripts should use os.path.dirname(__file__) to be robust regardless of where the script is run from. I also learned the Mesa contribution workflow including forking, branching, and PR process.

### Learning repo
🔗 My learning repo: https://github.com/himanksingh2024-svg/GSoC-learning-space
🔗 Relevant model(s): N/A (bug fix PR)

### Readiness checks
- [x] This PR addresses an agreed-upon problem (linked issue or discussion with maintainer approval), **or** is a small/trivial fix
- [ ] I have read the contributing guide and deprecation policy
- [ ] I have performed a self-review
- [ ] Another GSoC contributor has reviewed this PR: @<!-- tag reviewer here -->
- [ ] Tests pass locally
- [ ] Code is formatted
