### PR TITLE
mesa-3.x: Update CI to test stable

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: "3.14"
     - name: Install dependencies
       run: |
-        pip install mesa[network] --pre
+        pip install "mesa[network]<4"
         pip install .[test]
     - name: Test with pytest
       run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_examples.py

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -16,20 +16,7 @@ on:
     - cron: '0 6 * * 1'  # Monday at 6:00 UTC
 
 jobs:
-  # build-stable:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: "3.14"
-  #   - name: Install dependencies
-  #     run: pip install mesa[network] pytest
-  #   - name: Test with pytest
-  #     run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_examples.py
-
-  build-pre:
+  build-stable:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -44,7 +31,7 @@ jobs:
     - name: Test with pytest
       run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_examples.py
 
-  build-main:
+  build-3-maintenance:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -55,6 +42,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .[test]
-        pip install -U "mesa[network] @ git+https://github.com/mesa/mesa@main"
+        pip install -U "mesa[network] @ git+https://github.com/mesa/mesa@3.5.x-maintenance"
     - name: Test with pytest
       run: pytest -rA -Werror -Wdefault::PendingDeprecationWarning test_examples.py


### PR DESCRIPTION
On the new `mesa-3.x` maintenance branch, update the CI to target:
- The latest stable Mesa 3 release
- The [`3.5.x-maintenance`](https://github.com/mesa/mesa/tree/3.5.x-maintenance) branch