### PR TITLE
Fix forest fire networkx dependency

### DIFF
--- a/examples/forest_fire/requirements.txt
+++ b/examples/forest_fire/requirements.txt
@@ -1,2 +1,3 @@
 jupyter
 mesa[viz]>=3.0
+networkx


### PR DESCRIPTION
## GSoC contributor checklist

### Context & motivation
I am a beginner in open source, I went through many organizations and picked this particular organization and this particular project as it is simple and aligned with the skills I am good at.I was exploring the mesa-examples repository as part of my GSoC 2026 application for the Mesa Examples Revival project. I ran all 22 examples to understand the current state of the repo. When I ran the forest_fire example, I got a ModuleNotFoundError for networkx. I checked the requirements.txt and networkx was missing, so I added it.

### What I learned
I learned how Python dependency management works with requirements.txt. I also learned how to use git rebase to clean up a PR branch, and how the GitHub PR review process works. This was my first open source contribution. I am polishing my basic knowledge of  git commands. This gave me an exciting opportunity to learn and explore more of git and github and open source projects

### Learning repo
🔗 My learning repo: https://github.com/GITUSERMANOLYA/GSoC-learning-space
🔗 Relevant model(s): N/A

### Readiness checks
- [x] This PR addresses an agreed-upon problem (linked issue or discussion with maintainer approval), **or** is a small/trivial fix
- [x] I have read the contributing guide and deprecation policy
- [x] I have performed a self-review
- [x] Another GSoC contributor has reviewed this PR: @Harshini2411 
- [x] Tests pass locally
- [x] Code is formatted