### PR TITLE
fix(el_farol): update test to use num_agents instead of N

### DIFF
--- a/examples/el_farol/tests.py
+++ b/examples/el_farol/tests.py
@@ -9,7 +9,9 @@ def test_convergence():
     # Testing that the attendance converges to crowd_threshold
     attendances = []
     for _ in range(10):
-        model = ElFarolBar(num_agents=100, crowd_threshold=crowd_threshold, memory_size=10)
+        model = ElFarolBar(
+            num_agents=100, crowd_threshold=crowd_threshold, memory_size=10
+        )
         for _ in range(100):
             model.step()
         attendances.append(model.attendance)

--- a/examples/el_farol/tests.py
+++ b/examples/el_farol/tests.py
@@ -9,7 +9,7 @@ def test_convergence():
     # Testing that the attendance converges to crowd_threshold
     attendances = []
     for _ in range(10):
-        model = ElFarolBar(N=100, crowd_threshold=crowd_threshold, memory_size=10)
+        model = ElFarolBar(num_agents=100, crowd_threshold=crowd_threshold, memory_size=10)
         for _ in range(100):
             model.step()
         attendances.append(model.attendance)


### PR DESCRIPTION
### Summary
While checking the el_farol example in mesa-examples, I noticed the test was failing because the ElFarolBar constructor expects `num_agents`, but the test was passing `N`. This PR updates the test to use the correct parameter.
