### PR TITLE
Fix: Revive Deffuant-Weisbuch example for Mesa 3.x compatibility

### DIFF
--- a/examples/deffuant_weisbuch/deffuant_weisbuch/model.py
+++ b/examples/deffuant_weisbuch/deffuant_weisbuch/model.py
@@ -58,7 +58,8 @@ class DeffuantWeisbuchModel(Model):
         less than the confidence threshold, both agents update opinion values
         symmetrically.
         """
-        agent_list = self.agents.to_list()
+        agent_list = list(self.agents)
+        # this is fix by vanya
         for _ in range(self.n):
             agent_a, agent_b = self.random.sample(agent_list, 2)
             self.attempted_interactions += 1


### PR DESCRIPTION
This PR fixes the Deffuant-Weisbuch example, which was broken due to the removal of the .to_list() method in the Mesa 3.0+ AgentSet API.

Changes
Refactored model.py: Replaced the deprecated self.agents.to_list() call with the modern Pythonic list(self.agents) approach.

Mesa 3.3.1 Compatibility: Ensured the model logic aligns with the new high-performance AgentSet architecture.

Verification: Verified the fix by running the simulation via solara run app.py. The model now steps and updates opinion trajectories correctly without throwing an AttributeError.
I am Vanya Kapoor, a first year CSAI student at NSUT, applying for the "Reviving Mesa-examples" project. As part of my initial repository audit, I identified this as a high-priority API breaking change preventing community use of this model.

Related Audit Entry: deffuant_weisbuch ✗ broken AgentSet.to_list removed

CC: @jackiekazil  @EwoutH 