### PR TITLE
Add SEIR epidemic model with vaccination policy meta-agent

### DIFF
--- a/examples/seir_vaccination/README.md
+++ b/examples/seir_vaccination/README.md
@@ -1,0 +1,49 @@
+# SEIR Epidemic Model with Vaccination Policy
+
+**Mesa Version:** >=3.0 | **Visualization:** SolaraViz
+
+---
+
+## Overview
+
+This model simulates how a disease spreads through a population on a grid, and how a government responds when things get bad enough.
+
+Each person on the grid goes through four states — Susceptible, Exposed, Infected, and Recovered. A government meta-agent watches the infection rate every step and kicks off vaccination campaigns once it crosses a threshold, directly moving some susceptible people to recovered.
+
+The interesting part is watching the tension between how fast the disease spreads bottom-up and how quickly the government can slow it down top-down.
+
+---
+
+## How to Run
+
+```bash
+python -m venv venv
+source venv/bin/activate        # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+python -m solara run app.py
+```
+
+---
+
+## What the Colors Mean
+
+| Color | State | What it means |
+|---|---|---|
+| 🔵 Blue | Susceptible | Healthy, can be infected |
+| 🟠 Orange | Exposed | Infected but not contagious yet |
+| 🔴 Red | Infected | Contagious, spreading to neighbors |
+| 🟢 Green | Recovered | Immune, out of the chain |
+
+---
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `width` / `height` | 30 | Grid size |
+| `initial_infected` | 5 | How many people start infected |
+| `transmission_rate` | 0.3 | Chance of catching it from an infected neighbor |
+| `incubation_period` | 3 | Days before Exposed becomes contagious |
+| `infection_duration` | 7 | Days before recovery |
+| `vaccination_threshold` | 0.1 | Infection rate that triggers a campaign |
+| `vaccination_rate` | 0.05 | Fraction of susceptible people vaccinated per campaign |

--- a/examples/seir_vaccination/agents.py
+++ b/examples/seir_vaccination/agents.py
@@ -1,0 +1,94 @@
+from mesa.discrete_space import CellAgent
+
+
+class PersonAgent(CellAgent):
+    """
+    Represents a person in the population.
+
+    States:
+        S - Susceptible: healthy, can get infected
+        E - Exposed: infected but not yet contagious
+        I - Infected: contagious, can spread to neighbors
+        R - Recovered: immune, cannot be infected again
+    """
+
+    def __init__(self, model, state="S"):
+        super().__init__(model)
+        self.state = state
+        self.days_exposed = 0
+        self.days_infected = 0
+
+    def step(self):
+        if self.state == "S":
+            self._try_get_exposed()
+        elif self.state == "E":
+            self._progress_to_infected()
+        elif self.state == "I":
+            self._progress_to_recovered()
+
+    def _try_get_exposed(self):
+        """Check neighbors — if any are Infected, maybe become Exposed."""
+        for neighbor_cell in self.cell.connections.values():
+            for neighbor in neighbor_cell.agents:
+                if isinstance(neighbor, PersonAgent) and neighbor.state == "I":
+                    if self.random.random() < self.model.transmission_rate:
+                        self.state = "E"
+                        return
+
+    def _progress_to_infected(self):
+        """After incubation period, become Infected."""
+        self.days_exposed += 1
+        if self.days_exposed >= self.model.incubation_period:
+            self.state = "I"
+            self.days_exposed = 0
+
+    def _progress_to_recovered(self):
+        """After infection period, recover."""
+        self.days_infected += 1
+        if self.days_infected >= self.model.infection_duration:
+            self.state = "R"
+            self.days_infected = 0
+
+    def vaccinate(self):
+        """Directly move Susceptible person to Recovered via vaccination."""
+        if self.state == "S":
+            self.state = "R"
+
+
+class GovernmentAgent(CellAgent):
+    """
+    Meta-agent representing the government.
+
+    Monitors infection rate each step and triggers
+    vaccination campaigns when threshold is crossed.
+    """
+
+    def __init__(self, model):
+        super().__init__(model)
+        self.vaccination_active = False
+
+    def step(self):
+        self._monitor_and_respond()
+
+    def _monitor_and_respond(self):
+        """Check infection rate and trigger vaccination if needed."""
+        total = len(self.model.population)
+        if total == 0:
+            return
+
+        infected_count = sum(1 for a in self.model.population if a.state == "I")
+        infection_rate = infected_count / total
+
+        if infection_rate >= self.model.vaccination_threshold:
+            self.vaccination_active = True
+            self._run_vaccination_campaign()
+        else:
+            self.vaccination_active = False
+
+    def _run_vaccination_campaign(self):
+        """Vaccinate a fraction of susceptible people."""
+        susceptible = [a for a in self.model.population if a.state == "S"]
+        n_to_vaccinate = int(len(susceptible) * self.model.vaccination_rate)
+        targets = self.random.sample(susceptible, min(n_to_vaccinate, len(susceptible)))
+        for person in targets:
+            person.vaccinate()

--- a/examples/seir_vaccination/agents.py
+++ b/examples/seir_vaccination/agents.py
@@ -30,10 +30,13 @@ class PersonAgent(CellAgent):
         """Check neighbors — if any are Infected, maybe become Exposed."""
         for neighbor_cell in self.cell.connections.values():
             for neighbor in neighbor_cell.agents:
-                if isinstance(neighbor, PersonAgent) and neighbor.state == "I":
-                    if self.random.random() < self.model.transmission_rate:
-                        self.state = "E"
-                        return
+                if (
+                    isinstance(neighbor, PersonAgent)
+                    and neighbor.state == "I"
+                    and self.random.random() < self.model.transmission_rate
+                ):
+                    self.state = "E"
+                    return
 
     def _progress_to_infected(self):
         """After incubation period, become Infected."""

--- a/examples/seir_vaccination/app.py
+++ b/examples/seir_vaccination/app.py
@@ -1,0 +1,99 @@
+from mesa.visualization import SolaraViz, make_plot_component, make_space_component
+
+from .model import SEIRModel
+
+# Color mapping for each state
+STATE_COLORS = {
+    "S": "#3498db",  # Blue
+    "E": "#f39c12",  # Orange
+    "I": "#e74c3c",  # Red
+    "R": "#2ecc71",  # Green
+}
+
+
+def agent_portrayal(agent):
+    return {
+        "color": STATE_COLORS.get(agent.state, "grey"),
+        "size": 20,
+    }
+
+
+model_params = {
+    "width": {
+        "type": "SliderInt",
+        "value": 30,
+        "min": 10,
+        "max": 50,
+        "step": 5,
+        "label": "Grid Width",
+    },
+    "height": {
+        "type": "SliderInt",
+        "value": 30,
+        "min": 10,
+        "max": 50,
+        "step": 5,
+        "label": "Grid Height",
+    },
+    "initial_infected": {
+        "type": "SliderInt",
+        "value": 5,
+        "min": 1,
+        "max": 20,
+        "step": 1,
+        "label": "Initial Infected",
+    },
+    "transmission_rate": {
+        "type": "SliderFloat",
+        "value": 0.3,
+        "min": 0.0,
+        "max": 1.0,
+        "step": 0.05,
+        "label": "Transmission Rate",
+    },
+    "incubation_period": {
+        "type": "SliderInt",
+        "value": 3,
+        "min": 1,
+        "max": 10,
+        "step": 1,
+        "label": "Incubation Period (days)",
+    },
+    "infection_duration": {
+        "type": "SliderInt",
+        "value": 7,
+        "min": 1,
+        "max": 21,
+        "step": 1,
+        "label": "Infection Duration (days)",
+    },
+    "vaccination_threshold": {
+        "type": "SliderFloat",
+        "value": 0.1,
+        "min": 0.0,
+        "max": 0.5,
+        "step": 0.01,
+        "label": "Vaccination Threshold",
+    },
+    "vaccination_rate": {
+        "type": "SliderFloat",
+        "value": 0.05,
+        "min": 0.0,
+        "max": 0.3,
+        "step": 0.01,
+        "label": "Vaccination Rate per Campaign",
+    },
+}
+
+model = SEIRModel()
+
+space_component = make_space_component(agent_portrayal)
+epidemic_plot = make_plot_component(["Susceptible", "Exposed", "Infected", "Recovered"])
+vaccination_plot = make_plot_component(["Vaccination Active"])
+
+page = SolaraViz(
+    model,
+    components=[space_component, epidemic_plot, vaccination_plot],
+    model_params=model_params,
+    name="SEIR Epidemic Model with Vaccination Policy",
+)

--- a/examples/seir_vaccination/model.py
+++ b/examples/seir_vaccination/model.py
@@ -1,0 +1,84 @@
+from mesa import Model
+from mesa.datacollection import DataCollector
+from mesa.discrete_space import OrthogonalMooreGrid
+
+from .agents import GovernmentAgent, PersonAgent
+
+
+class SEIRModel(Model):
+    """
+    SEIR Epidemic Model with Vaccination Policy.
+
+    Models population-level disease spreading on a grid.
+    A GovernmentAgent monitors infection rates and triggers
+    vaccination campaigns when a threshold is crossed.
+
+    Activation order (explicit, Mesa 3.x style):
+        1. PersonAgents step (spreading, progression)
+        2. GovernmentAgent steps (monitors and responds)
+    """
+
+    def __init__(
+        self,
+        width=30,
+        height=30,
+        initial_infected=5,
+        transmission_rate=0.3,
+        incubation_period=3,
+        infection_duration=7,
+        vaccination_threshold=0.1,
+        vaccination_rate=0.05,
+    ):
+        super().__init__()
+
+        self.width = width
+        self.height = height
+        self.initial_infected = initial_infected
+        self.transmission_rate = transmission_rate
+        self.incubation_period = incubation_period
+        self.infection_duration = infection_duration
+        self.vaccination_threshold = vaccination_threshold
+        self.vaccination_rate = vaccination_rate
+
+        # Grid setup — Mesa 3.5 Cell API
+        self.grid = OrthogonalMooreGrid((width, height), torus=False, capacity=1)
+
+        # Track population separately for easy access
+        self.population = []
+
+        # Place one person per cell
+        for cell in self.grid.all_cells:
+            person = PersonAgent(self, state="S")
+            person.cell = cell
+            self.population.append(person)
+
+        # Seed initial infections
+        initial_infected_agents = self.random.sample(self.population, initial_infected)
+        for agent in initial_infected_agents:
+            agent.state = "I"
+
+        # Government meta-agent (not placed on grid)
+        self.government = GovernmentAgent(self)
+
+        self.datacollector = DataCollector(
+            model_reporters={
+                "Susceptible": lambda m: sum(1 for a in m.population if a.state == "S"),
+                "Exposed": lambda m: sum(1 for a in m.population if a.state == "E"),
+                "Infected": lambda m: sum(1 for a in m.population if a.state == "I"),
+                "Recovered": lambda m: sum(1 for a in m.population if a.state == "R"),
+                "Vaccination Active": lambda m: int(m.government.vaccination_active),
+            }
+        )
+
+        self.datacollector.collect(self)
+        self.running = True
+
+    def step(self):
+        # 1. All people act first
+        for person in self.population:
+            person.step()
+
+        # 2. Government monitors and responds
+        self.government.step()
+
+        self.datacollector.collect(self)


### PR DESCRIPTION
Summary
Adds a SEIR epidemic model with a government vaccination policy meta-agent.
Motive
There's no population-level epidemic spreading example in mesa-examples. The existing virus_antibody model works at the biological/cellular level, but nothing shows how a disease spreads through a population on a grid and how a policy intervention affects that. This fills that gap.
Implementation
PersonAgents move through four states -Susceptible, Exposed, Infected, Recovered, based on contact with infected neighbors. A GovernmentAgent monitors the infection rate each step and triggers vaccination campaigns when it crosses a threshold. Activation is explicit and bottom-up: people act first, then the government responds. No legacy schedulers used.
Usage
pip install mesa[rec]
python -m solara run app.py
Closes #350
@tpike3 @EwoutH
