### PR TITLE
Add misinformation spread model: LLM-powered agents vs rule-based com…

### DIFF
--- a/examples/misinformation_spread/misinformation_spread/agents.py
+++ b/examples/misinformation_spread/misinformation_spread/agents.py
@@ -1,0 +1,104 @@
+import mesa
+from mesa.discrete_space.cell_agent import BasicMovement, HasCell
+from mesa_llm.llm_agent import LLMAgent
+from mesa_llm.reasoning.react import ReActReasoning
+
+from misinformation_spread.tools import (  # noqa: F401 — import so @tool registers them
+    check_neighbors,
+    challenge_rumor,
+    spread_rumor,
+    update_belief,
+)
+
+
+class CitizenAgent(LLMAgent, HasCell, BasicMovement):
+    def __init__(self, model, name, persona, initial_stance, initial_belief):
+        super().__init__(
+            model=model,
+            reasoning=ReActReasoning,
+            llm_model=model.llm_model,
+            system_prompt=(
+                f"You are {name}, a citizen in a small community. {persona}"
+            ),
+        )
+        # Remove built-in movement tools that confuse the small LLM
+        # We only want our custom tools (check_neighbors, spread_rumor,
+        # challenge_rumor, update_belief) for communication
+        for tool_name in ["move_one_step", "teleport_to_location", "speak_to"]:
+            self.tool_manager.tools.pop(tool_name, None)
+
+        self.name = name
+        self.stance = initial_stance
+        self.belief_score = initial_belief
+
+    def step(self):
+        prompt = (
+            f"You are currently a {self.stance} with belief score {self.belief_score:.2f}.\n"
+            f'The rumor is: "{self.model.rumor}"\n\n'
+            f"You MUST follow these steps in order:\n"
+            f"Step 1: Call check_neighbors to see who is nearby. Look at the agent IDs in the result.\n"
+            f"Step 2: Pick ONE agent ID from the check_neighbors result. "
+            f"If your belief score is above 0.5, call spread_rumor with that agent's ID. "
+            f"If your belief score is 0.5 or below, call challenge_rumor with that agent's ID. "
+            f"IMPORTANT: Only use agent IDs that appeared in the check_neighbors result.\n"
+            f"Step 3: Call update_belief with a new score. "
+            f"If you spread the rumor, increase your score slightly (add 0.05). "
+            f"If you challenged it, decrease your score slightly (subtract 0.05).\n"
+        )
+        plan = self.reasoning.plan(prompt=prompt)
+        self.apply_plan(plan)
+
+        # Workaround: small LLMs (e.g. Gemma 3 1B) struggle with multi-step
+        # ReAct tool calling — they often skip update_belief or hallucinate
+        # agent IDs. We apply belief updates programmatically based on which
+        # communication tool the LLM actually invoked.
+        # The plan object stores tool calls at plan.llm_plan.tool_calls,
+        # where each entry is a ChatCompletionMessageToolCall with
+        # .function.name for the tool name.
+        tool_calls = getattr(getattr(plan, 'llm_plan', None), 'tool_calls', None)
+        if tool_calls:
+            called_tools = {tc.function.name for tc in tool_calls}
+            if 'spread_rumor' in called_tools:
+                self.belief_score = min(1.0, self.belief_score + 0.05)
+            elif 'challenge_rumor' in called_tools:
+                self.belief_score = max(0.0, self.belief_score - 0.05)
+
+            # Update stance based on new score
+            if self.belief_score > 0.7:
+                self.stance = "believer"
+            elif self.belief_score < 0.3:
+                self.stance = "skeptic"
+            else:
+                self.stance = "neutral"
+
+
+class RuleBasedAgent(mesa.Agent, HasCell, BasicMovement):
+    def __init__(self, model, name, persona, initial_stance, initial_belief):
+        super().__init__(model=model)
+        self.name = name
+        self.stance = initial_stance
+        self.belief_score = initial_belief
+
+    def step(self):
+        neighbors = [
+            agent
+            for cell in self.cell.neighborhood
+            for agent in cell.agents
+        ]
+
+        for neighbor in neighbors:
+            if neighbor.stance == "believer":
+                self.belief_score += 0.1 * (1 - self.belief_score)
+            elif neighbor.stance == "skeptic":
+                self.belief_score -= 0.1 * self.belief_score
+            else:
+                self.belief_score += self.random.uniform(-0.02, 0.02)
+
+        self.belief_score = max(0.0, min(1.0, self.belief_score))
+
+        if self.belief_score > 0.7:
+            self.stance = "believer"
+        elif self.belief_score < 0.3:
+            self.stance = "skeptic"
+        else:
+            self.stance = "neutral"

--- a/examples/misinformation_spread/misinformation_spread/agents.py
+++ b/examples/misinformation_spread/misinformation_spread/agents.py
@@ -4,8 +4,8 @@ from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.reasoning.react import ReActReasoning
 
 from misinformation_spread.tools import (  # noqa: F401 — import so @tool registers them
-    check_neighbors,
     challenge_rumor,
+    check_neighbors,
     spread_rumor,
     update_belief,
 )
@@ -55,12 +55,12 @@ class CitizenAgent(LLMAgent, HasCell, BasicMovement):
         # The plan object stores tool calls at plan.llm_plan.tool_calls,
         # where each entry is a ChatCompletionMessageToolCall with
         # .function.name for the tool name.
-        tool_calls = getattr(getattr(plan, 'llm_plan', None), 'tool_calls', None)
+        tool_calls = getattr(getattr(plan, "llm_plan", None), "tool_calls", None)
         if tool_calls:
             called_tools = {tc.function.name for tc in tool_calls}
-            if 'spread_rumor' in called_tools:
+            if "spread_rumor" in called_tools:
                 self.belief_score = min(1.0, self.belief_score + 0.05)
-            elif 'challenge_rumor' in called_tools:
+            elif "challenge_rumor" in called_tools:
                 self.belief_score = max(0.0, self.belief_score - 0.05)
 
             # Update stance based on new score
@@ -80,11 +80,7 @@ class RuleBasedAgent(mesa.Agent, HasCell, BasicMovement):
         self.belief_score = initial_belief
 
     def step(self):
-        neighbors = [
-            agent
-            for cell in self.cell.neighborhood
-            for agent in cell.agents
-        ]
+        neighbors = [agent for cell in self.cell.neighborhood for agent in cell.agents]
 
         for neighbor in neighbors:
             if neighbor.stance == "believer":

--- a/examples/misinformation_spread/misinformation_spread/model.py
+++ b/examples/misinformation_spread/misinformation_spread/model.py
@@ -18,7 +18,9 @@ class MisinformationModel(mesa.Model):
             "chemicals from the nearby factory."
         )
 
-        self.grid = OrthogonalMooreGrid((width, height), capacity=1, torus=True, random=self.random)
+        self.grid = OrthogonalMooreGrid(
+            (width, height), capacity=1, torus=True, random=self.random
+        )
 
         agent_configs = [
             {
@@ -110,12 +112,8 @@ class MisinformationModel(mesa.Model):
                 "believers": lambda m: sum(
                     1 for a in m.agents if a.stance == "believer"
                 ),
-                "skeptics": lambda m: sum(
-                    1 for a in m.agents if a.stance == "skeptic"
-                ),
-                "neutrals": lambda m: sum(
-                    1 for a in m.agents if a.stance == "neutral"
-                ),
+                "skeptics": lambda m: sum(1 for a in m.agents if a.stance == "skeptic"),
+                "neutrals": lambda m: sum(1 for a in m.agents if a.stance == "neutral"),
                 "avg_belief": lambda m: sum(a.belief_score for a in m.agents)
                 / len(m.agents),
             },
@@ -228,12 +226,8 @@ class RuleBasedModel(mesa.Model):
                 "believers": lambda m: sum(
                     1 for a in m.agents if a.stance == "believer"
                 ),
-                "skeptics": lambda m: sum(
-                    1 for a in m.agents if a.stance == "skeptic"
-                ),
-                "neutrals": lambda m: sum(
-                    1 for a in m.agents if a.stance == "neutral"
-                ),
+                "skeptics": lambda m: sum(1 for a in m.agents if a.stance == "skeptic"),
+                "neutrals": lambda m: sum(1 for a in m.agents if a.stance == "neutral"),
                 "avg_belief": lambda m: sum(a.belief_score for a in m.agents)
                 / len(m.agents),
             },

--- a/examples/misinformation_spread/misinformation_spread/model.py
+++ b/examples/misinformation_spread/misinformation_spread/model.py
@@ -1,0 +1,248 @@
+import mesa
+from dotenv import load_dotenv
+from mesa.datacollection import DataCollector
+from mesa.discrete_space import OrthogonalMooreGrid
+
+from misinformation_spread.agents import CitizenAgent, RuleBasedAgent
+
+
+class MisinformationModel(mesa.Model):
+    def __init__(self, width=5, height=5, llm_model="ollama/llama3.2:3b"):
+        super().__init__()
+
+        load_dotenv()
+
+        self.llm_model = llm_model
+        self.rumor = (
+            "The town's water supply has been contaminated with dangerous "
+            "chemicals from the nearby factory."
+        )
+
+        self.grid = OrthogonalMooreGrid((width, height), capacity=1, torus=True, random=self.random)
+
+        agent_configs = [
+            {
+                "name": "Maria",
+                "persona": "A cautious schoolteacher who values evidence and critical thinking. You don't believe things easily.",
+                "initial_stance": "skeptic",
+                "initial_belief": 0.2,
+            },
+            {
+                "name": "Carlos",
+                "persona": "An anxious shopkeeper who worries about health risks. You tend to believe warnings about safety.",
+                "initial_stance": "believer",
+                "initial_belief": 0.8,
+            },
+            {
+                "name": "Priya",
+                "persona": "A young university student studying chemistry. You trust scientific sources over gossip.",
+                "initial_stance": "skeptic",
+                "initial_belief": 0.15,
+            },
+            {
+                "name": "James",
+                "persona": "A retired factory worker who distrusts the factory owners. You've always suspected they cut corners on safety.",
+                "initial_stance": "believer",
+                "initial_belief": 0.85,
+            },
+            {
+                "name": "Aisha",
+                "persona": "A community health worker who has seen real contamination cases before. You take such claims seriously but want proof.",
+                "initial_stance": "neutral",
+                "initial_belief": 0.5,
+            },
+            {
+                "name": "Tom",
+                "persona": "A local journalist always looking for a story. You're curious but need verification before reporting.",
+                "initial_stance": "neutral",
+                "initial_belief": 0.45,
+            },
+            {
+                "name": "Lin",
+                "persona": "A grandmother who has lived here for 50 years. You trust your instincts and community word-of-mouth.",
+                "initial_stance": "neutral",
+                "initial_belief": 0.55,
+            },
+            {
+                "name": "David",
+                "persona": "A government water inspector who knows the water is tested regularly. You're confident the water is safe.",
+                "initial_stance": "skeptic",
+                "initial_belief": 0.1,
+            },
+            {
+                "name": "Sofia",
+                "persona": "A social media enthusiast who shares things quickly. You tend to amplify information without checking.",
+                "initial_stance": "believer",
+                "initial_belief": 0.75,
+            },
+            {
+                "name": "Raj",
+                "persona": "A doctor at the local clinic. You rely on medical data and are skeptical of unverified health claims.",
+                "initial_stance": "skeptic",
+                "initial_belief": 0.2,
+            },
+            {
+                "name": "Emma",
+                "persona": "A stay-at-home parent concerned about children's health. You err on the side of caution.",
+                "initial_stance": "neutral",
+                "initial_belief": 0.6,
+            },
+            {
+                "name": "Mike",
+                "persona": "A laid-back bartender who hears all sorts of gossip. You don't take rumors seriously.",
+                "initial_stance": "neutral",
+                "initial_belief": 0.4,
+            },
+        ]
+
+        for config in agent_configs:
+            agent = CitizenAgent(
+                model=self,
+                name=config["name"],
+                persona=config["persona"],
+                initial_stance=config["initial_stance"],
+                initial_belief=config["initial_belief"],
+            )
+            agent.move_to(self.grid.select_random_empty_cell())
+
+        self.datacollector = DataCollector(
+            model_reporters={
+                "believers": lambda m: sum(
+                    1 for a in m.agents if a.stance == "believer"
+                ),
+                "skeptics": lambda m: sum(
+                    1 for a in m.agents if a.stance == "skeptic"
+                ),
+                "neutrals": lambda m: sum(
+                    1 for a in m.agents if a.stance == "neutral"
+                ),
+                "avg_belief": lambda m: sum(a.belief_score for a in m.agents)
+                / len(m.agents),
+            },
+            agent_reporters={
+                "belief_score": "belief_score",
+                "stance": "stance",
+            },
+        )
+
+    def step(self):
+        self.agents.shuffle_do("step")
+        self.datacollector.collect(self)
+
+
+class RuleBasedModel(mesa.Model):
+    def __init__(self, width=5, height=5):
+        super().__init__()
+
+        self.grid = OrthogonalMooreGrid(
+            (width, height), capacity=1, torus=True, random=self.random
+        )
+
+        agent_configs = [
+            {
+                "name": "Maria",
+                "persona": "A cautious schoolteacher who values evidence and critical thinking.",
+                "initial_stance": "skeptic",
+                "initial_belief": 0.2,
+            },
+            {
+                "name": "Carlos",
+                "persona": "An anxious shopkeeper who worries about health risks.",
+                "initial_stance": "believer",
+                "initial_belief": 0.8,
+            },
+            {
+                "name": "Priya",
+                "persona": "A young university student studying chemistry.",
+                "initial_stance": "skeptic",
+                "initial_belief": 0.15,
+            },
+            {
+                "name": "James",
+                "persona": "A retired factory worker who distrusts the factory owners.",
+                "initial_stance": "believer",
+                "initial_belief": 0.85,
+            },
+            {
+                "name": "Aisha",
+                "persona": "A community health worker.",
+                "initial_stance": "neutral",
+                "initial_belief": 0.5,
+            },
+            {
+                "name": "Tom",
+                "persona": "A local journalist always looking for a story.",
+                "initial_stance": "neutral",
+                "initial_belief": 0.45,
+            },
+            {
+                "name": "Lin",
+                "persona": "A grandmother who has lived here for 50 years.",
+                "initial_stance": "neutral",
+                "initial_belief": 0.55,
+            },
+            {
+                "name": "David",
+                "persona": "A government water inspector.",
+                "initial_stance": "skeptic",
+                "initial_belief": 0.1,
+            },
+            {
+                "name": "Sofia",
+                "persona": "A social media enthusiast who shares things quickly.",
+                "initial_stance": "believer",
+                "initial_belief": 0.75,
+            },
+            {
+                "name": "Raj",
+                "persona": "A doctor at the local clinic.",
+                "initial_stance": "skeptic",
+                "initial_belief": 0.2,
+            },
+            {
+                "name": "Emma",
+                "persona": "A stay-at-home parent concerned about children's health.",
+                "initial_stance": "neutral",
+                "initial_belief": 0.6,
+            },
+            {
+                "name": "Mike",
+                "persona": "A laid-back bartender who hears all sorts of gossip.",
+                "initial_stance": "neutral",
+                "initial_belief": 0.4,
+            },
+        ]
+
+        for config in agent_configs:
+            agent = RuleBasedAgent(
+                model=self,
+                name=config["name"],
+                persona=config["persona"],
+                initial_stance=config["initial_stance"],
+                initial_belief=config["initial_belief"],
+            )
+            agent.move_to(self.grid.select_random_empty_cell())
+
+        self.datacollector = DataCollector(
+            model_reporters={
+                "believers": lambda m: sum(
+                    1 for a in m.agents if a.stance == "believer"
+                ),
+                "skeptics": lambda m: sum(
+                    1 for a in m.agents if a.stance == "skeptic"
+                ),
+                "neutrals": lambda m: sum(
+                    1 for a in m.agents if a.stance == "neutral"
+                ),
+                "avg_belief": lambda m: sum(a.belief_score for a in m.agents)
+                / len(m.agents),
+            },
+            agent_reporters={
+                "belief_score": "belief_score",
+                "stance": "stance",
+            },
+        )
+
+    def step(self):
+        self.agents.shuffle_do("step")
+        self.datacollector.collect(self)

--- a/examples/misinformation_spread/misinformation_spread/tools.py
+++ b/examples/misinformation_spread/misinformation_spread/tools.py
@@ -1,0 +1,90 @@
+from mesa_llm.tools.tool_decorator import tool
+
+
+@tool
+def check_neighbors(agent):
+    """Check who is nearby and what they believe about the rumor.
+
+    Returns a formatted list of neighboring agents with their current stance
+    on the rumor (believer, skeptic, or neutral).
+    """
+    neighbors = []
+    for cell in agent.cell.neighborhood:
+        for neighbor in cell.agents:
+            if neighbor is not agent:
+                neighbors.append(neighbor)
+
+    if not neighbors:
+        return "No neighbors nearby."
+
+    lines = []
+    for n in neighbors:
+        lines.append(f"- Agent {n.unique_id} ({n.name}): {n.stance}")
+    return "Nearby agents:\n" + "\n".join(lines)
+
+
+@tool
+def spread_rumor(agent, target_id: int):
+    """Spread the rumor to a specific agent to try to convince them.
+
+    Args:
+        target_id: The unique_id of the agent to spread the rumor to.
+    """
+    target = None
+    for a in agent.model.agents:
+        if a.unique_id == target_id:
+            target = a
+            break
+
+    if target is None:
+        return f"Could not find agent with id {target_id}."
+
+    message = f"Have you heard? {agent.model.rumor}"
+    agent.send_message(message, [target])
+    return f"Spread the rumor to Agent {target_id} ({target.name})."
+
+
+@tool
+def challenge_rumor(agent, target_id: int):
+    """Challenge the rumor by sending a counter-argument to a specific agent.
+
+    Args:
+        target_id: The unique_id of the agent to send the counter-argument to.
+    """
+    target = None
+    for a in agent.model.agents:
+        if a.unique_id == target_id:
+            target = a
+            break
+
+    if target is None:
+        return f"Could not find agent with id {target_id}."
+
+    message = f"I don't believe the rumor: {agent.model.rumor}. I think it's false."
+    agent.send_message(message, [target])
+    return f"Challenged the rumor with Agent {target_id} ({target.name})."
+
+
+@tool
+def update_belief(agent, new_score: float):
+    """Update personal belief score and stance based on new information.
+
+    Args:
+        new_score: The new belief score between 0.0 (disbelief) and 1.0 (full belief).
+    """
+    try:
+        new_score = float(new_score)
+    except (ValueError, TypeError):
+        return f"Error: new_score must be a number, got {new_score}"
+
+    clamped = max(0.0, min(1.0, new_score))
+    agent.belief_score = clamped
+
+    if clamped > 0.7:
+        agent.stance = "believer"
+    elif clamped < 0.3:
+        agent.stance = "skeptic"
+    else:
+        agent.stance = "neutral"
+
+    return f"Updated belief score to {clamped:.2f}. Stance is now: {agent.stance}."

--- a/examples/misinformation_spread/readme.md
+++ b/examples/misinformation_spread/readme.md
@@ -1,0 +1,42 @@
+# Misinformation Spread Model
+
+## Summary
+
+An agent-based model simulating the spread of misinformation through a small community, built with mesa-llm. LLM-powered agents with unique personas (teacher, shopkeeper, journalist, doctor, etc.) reason about whether to spread or challenge a rumor about water contamination. Includes a rule-based comparison model to demonstrate the difference between LLM-driven and traditional agent behavior.
+
+This model demonstrates mesa-llm features including: ReAct reasoning, custom tools, inter-agent communication, and memory.
+
+## How to Run
+
+### LLM Version (requires Ollama)
+
+1. Install Ollama from https://ollama.com
+2. Pull a model: `ollama pull llama3.2:3b`
+3. Run: `python run.py`
+
+### Rule-Based Version (no LLM needed)
+
+```
+python run_comparison.py
+```
+
+## Files
+
+- `misinformation_spread/model.py`: MisinformationModel (LLM) and RuleBasedModel (rule-based) classes
+- `misinformation_spread/agents.py`: CitizenAgent (LLM-powered) and RuleBasedAgent classes
+- `misinformation_spread/tools.py`: Custom tools for agent actions (check_neighbors, spread_rumor, challenge_rumor, update_belief)
+- `run.py`: Runs the LLM simulation for 5 steps with 12 agents and plots results
+- `run_comparison.py`: Runs the rule-based simulation for 10 steps and plots results
+
+## Key Findings
+
+- Small local LLMs (3B parameters) struggle with multi-step tool calling in mesa-llm's ReAct loop
+- Built-in mesa-llm tools can confuse agents — removing unnecessary ones improves behavior
+- Rule-based model runs instantly vs 25+ minutes for LLM version with local inference
+- LLM agents show personality-driven reasoning but need larger models for reliable tool use
+
+## Further Reading
+
+- [Mesa-LLM documentation](https://mesa-llm.readthedocs.io)
+- [Mesa framework](https://mesa.readthedocs.io)
+- [Generative Agents paper](https://arxiv.org/abs/2304.03442)

--- a/examples/misinformation_spread/requirements.txt
+++ b/examples/misinformation_spread/requirements.txt
@@ -1,0 +1,3 @@
+mesa>=3.0
+mesa-llm>=0.2.0
+matplotlib

--- a/examples/misinformation_spread/run.py
+++ b/examples/misinformation_spread/run.py
@@ -1,0 +1,48 @@
+import matplotlib.pyplot as plt
+
+from misinformation_spread.model import MisinformationModel
+
+
+def main():
+    print("Starting Misinformation Spread Simulation...")
+    model = MisinformationModel()
+
+    num_steps = 5
+    for i in range(num_steps):
+        print(f"\n--- Step {i + 1} ---")
+        model.step()
+
+        for agent in model.agents:
+            print(f"  {agent.name:8s} | stance: {agent.stance:8s} | belief: {agent.belief_score:.2f}")
+
+        believers = sum(1 for a in model.agents if a.stance == "believer")
+        skeptics = sum(1 for a in model.agents if a.stance == "skeptic")
+        neutrals = sum(1 for a in model.agents if a.stance == "neutral")
+        print(f"\n  Summary: {believers} believers, {skeptics} skeptics, {neutrals} neutrals")
+
+    # Plot model-level results
+    model_data = model.datacollector.get_model_vars_dataframe()
+
+    plt.figure(figsize=(10, 6))
+    plt.plot(model_data["believers"], color="red", label="Believers", marker="o")
+    plt.plot(model_data["skeptics"], color="blue", label="Skeptics", marker="s")
+    plt.plot(model_data["neutrals"], color="gray", label="Neutrals", marker="^")
+    plt.xlabel("Step")
+    plt.ylabel("Number of Agents")
+    plt.title("Misinformation Spread Over Time")
+    plt.legend()
+    plt.grid(True)
+    plt.savefig("results.png")
+    print("\nPlot saved to results.png")
+    plt.show()
+
+    # Print final agent belief scores
+    agent_data = model.datacollector.get_agent_vars_dataframe()
+    print("\n--- Final Belief Scores ---")
+    last_step = agent_data.xs(num_steps - 1, level="Step")
+    for agent_id, row in last_step.iterrows():
+        print(f"  Agent {agent_id:3d} | stance: {row['stance']:8s} | belief: {row['belief_score']:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/misinformation_spread/run.py
+++ b/examples/misinformation_spread/run.py
@@ -1,5 +1,4 @@
 import matplotlib.pyplot as plt
-
 from misinformation_spread.model import MisinformationModel
 
 
@@ -13,12 +12,16 @@ def main():
         model.step()
 
         for agent in model.agents:
-            print(f"  {agent.name:8s} | stance: {agent.stance:8s} | belief: {agent.belief_score:.2f}")
+            print(
+                f"  {agent.name:8s} | stance: {agent.stance:8s} | belief: {agent.belief_score:.2f}"
+            )
 
         believers = sum(1 for a in model.agents if a.stance == "believer")
         skeptics = sum(1 for a in model.agents if a.stance == "skeptic")
         neutrals = sum(1 for a in model.agents if a.stance == "neutral")
-        print(f"\n  Summary: {believers} believers, {skeptics} skeptics, {neutrals} neutrals")
+        print(
+            f"\n  Summary: {believers} believers, {skeptics} skeptics, {neutrals} neutrals"
+        )
 
     # Plot model-level results
     model_data = model.datacollector.get_model_vars_dataframe()
@@ -41,7 +44,9 @@ def main():
     print("\n--- Final Belief Scores ---")
     last_step = agent_data.xs(num_steps - 1, level="Step")
     for agent_id, row in last_step.iterrows():
-        print(f"  Agent {agent_id:3d} | stance: {row['stance']:8s} | belief: {row['belief_score']:.2f}")
+        print(
+            f"  Agent {agent_id:3d} | stance: {row['stance']:8s} | belief: {row['belief_score']:.2f}"
+        )
 
 
 if __name__ == "__main__":

--- a/examples/misinformation_spread/run_comparison.py
+++ b/examples/misinformation_spread/run_comparison.py
@@ -1,0 +1,75 @@
+import matplotlib.pyplot as plt
+
+from misinformation_spread.model import RuleBasedModel
+
+
+def main():
+    print("Starting Rule-Based Misinformation Simulation...")
+    print("(No LLM required — runs instantly)\n")
+
+    model = RuleBasedModel()
+    num_steps = 10
+
+    for i in range(num_steps):
+        print(f"--- Step {i + 1} ---")
+        model.step()
+
+        for agent in model.agents:
+            print(
+                f"  {agent.name:8s} | stance: {agent.stance:8s} | belief: {agent.belief_score:.2f}"
+            )
+
+        believers = sum(1 for a in model.agents if a.stance == "believer")
+        skeptics = sum(1 for a in model.agents if a.stance == "skeptic")
+        neutrals = sum(1 for a in model.agents if a.stance == "neutral")
+        print(f"  Summary: {believers} believers, {skeptics} skeptics, {neutrals} neutrals\n")
+
+    # Plot results
+    model_data = model.datacollector.get_model_vars_dataframe()
+
+    plt.figure(figsize=(10, 6))
+    plt.plot(model_data["believers"], color="red", label="Believers", marker="o")
+    plt.plot(model_data["skeptics"], color="blue", label="Skeptics", marker="s")
+    plt.plot(model_data["neutrals"], color="gray", label="Neutrals", marker="^")
+    plt.xlabel("Step")
+    plt.ylabel("Number of Agents")
+    plt.title("Rule-Based Misinformation Spread Over Time")
+    plt.legend()
+    plt.grid(True)
+    plt.savefig("results_rulebased.png")
+    print("Plot saved to results_rulebased.png")
+    plt.show()
+
+    # Print final agent belief scores
+    agent_data = model.datacollector.get_agent_vars_dataframe()
+    print("\n--- Final Belief Scores ---")
+    last_step = agent_data.xs(num_steps - 1, level="Step")
+    for agent_id, row in last_step.iterrows():
+        print(
+            f"  Agent {agent_id:3d} | stance: {row['stance']:8s} | belief: {row['belief_score']:.2f}"
+        )
+
+    # Comparison note
+    print("\n" + "=" * 60)
+    print("COMPARISON: Rule-Based vs LLM-Based Model")
+    print("=" * 60)
+    print(
+        "Rule-based model: Agents follow fixed mathematical rules.\n"
+        "  - Believers increase neighbors' belief by 0.1*(1-score)\n"
+        "  - Skeptics decrease neighbors' belief by 0.1*score\n"
+        "  - Neutral neighbors add small random noise (+/-0.02)\n"
+        "  - Deterministic (aside from grid placement and neutral noise)\n"
+        "  - Runs instantly, good for parameter sweeps\n"
+        "\n"
+        "LLM-based model: Agents use an LLM to reason about actions.\n"
+        "  - Each agent has a unique persona influencing decisions\n"
+        "  - Agents choose whether to spread or challenge the rumor\n"
+        "  - Emergent behavior from natural language reasoning\n"
+        "  - Non-deterministic, slower, but captures richer dynamics\n"
+        "\n"
+        "Run 'python run.py' to compare with the LLM version."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/misinformation_spread/run_comparison.py
+++ b/examples/misinformation_spread/run_comparison.py
@@ -1,5 +1,4 @@
 import matplotlib.pyplot as plt
-
 from misinformation_spread.model import RuleBasedModel
 
 
@@ -22,7 +21,9 @@ def main():
         believers = sum(1 for a in model.agents if a.stance == "believer")
         skeptics = sum(1 for a in model.agents if a.stance == "skeptic")
         neutrals = sum(1 for a in model.agents if a.stance == "neutral")
-        print(f"  Summary: {believers} believers, {skeptics} skeptics, {neutrals} neutrals\n")
+        print(
+            f"  Summary: {believers} believers, {skeptics} skeptics, {neutrals} neutrals\n"
+        )
 
     # Plot results
     model_data = model.datacollector.get_model_vars_dataframe()


### PR DESCRIPTION
Adds a new example model demonstrating mesa-llm features through a misinformation spread simulation.

## What this model does
12 agents with unique personas (teacher, doctor, journalist, shopkeeper, etc.) are placed on a grid and react to a rumor about water contamination. LLM-powered agents use ReAct reasoning to decide whether to spread or challenge the rumor based on their personality and conversations with neighbors.

A rule-based comparison model with the same agents and setup uses simple mathematical rules instead of LLMs, allowing direct comparison of the two approaches.

## Features demonstrated
- mesa-llm LLMAgent with ReAct reasoning
- Custom tools (@tool decorator): check_neighbors, spread_rumor, challenge_rumor, update_belief
- Inter-agent communication via send_message
- Memory system for tracking conversations
- DataCollector for tracking belief dynamics
- Rule-based vs LLM agent comparison

## Files
- `misinformation_spread/agents.py` — CitizenAgent (LLM) and RuleBasedAgent
- `misinformation_spread/model.py` — MisinformationModel and RuleBasedModel
- `misinformation_spread/tools.py` — Custom agent tools
- `run.py` — Runs LLM simulation (requires Ollama)
- `run_comparison.py` — Runs rule-based simulation (no LLM needed)
- `readme.md` — Documentation and findings