### PR TITLE
Add Boltzmann wealth model example

### DIFF
--- a/boltzmann_wealth/README.md
+++ b/boltzmann_wealth/README.md
@@ -1,0 +1,27 @@
+# Boltzmann Wealth Model
+
+## Summary
+A simple agent-based model demonstrating wealth distribution.
+Each agent starts with 1 unit of wealth and randomly gives it
+to another agent each step. Over time, wealth inequality emerges
+even though everyone started equal.
+
+## How to Run
+Install dependencies:
+```
+pip install mesa seaborn matplotlib
+```
+
+Run the model:
+```
+python model.py
+```
+
+## What You Will See
+A histogram showing wealth distribution after 30 steps.
+Most agents end up with 0 wealth while a few become rich.
+
+## Key Concepts
+- **Agents**: Individual people with wealth
+- **Exchange**: Random wealth transfer each step
+- **Emergence**: Inequality appears from equal starting conditions

--- a/boltzmann_wealth/model.py
+++ b/boltzmann_wealth/model.py
@@ -1,0 +1,42 @@
+import mesa
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+class MoneyAgent(mesa.Agent):
+    """An agent with fixed initial wealth."""
+
+    def __init__(self, model):
+        super().__init__(model)
+        self.wealth = 1
+
+    def exchange(self):
+        if self.wealth > 0:
+            other_agent = self.random.choice(self.model.agents)
+            if other_agent is not None:
+                other_agent.wealth += 1
+                self.wealth -= 1
+
+
+class MoneyModel(mesa.Model):
+    """A model with some number of agents."""
+
+    def __init__(self, n=10, seed=None):
+        super().__init__(seed=seed)
+        self.num_agents = n
+        MoneyAgent.create_agents(model=self, n=n)
+
+    def step(self):
+        self.agents.shuffle_do("exchange")
+
+
+if __name__ == "__main__":
+    model = MoneyModel(10)
+    for _ in range(30):
+        model.step()
+
+    agent_wealth = [a.wealth for a in model.agents]
+    g = sns.histplot(agent_wealth, discrete=True)
+    g.set(
+        title="Wealth distribution", xlabel="Wealth", ylabel="number of agents"
+    )
+    plt.show()

--- a/boltzmann_wealth/model.py
+++ b/boltzmann_wealth/model.py
@@ -1,6 +1,7 @@
+import matplotlib.pyplot as plt
 import mesa
 import seaborn as sns
-import matplotlib.pyplot as plt
+
 
 class MoneyAgent(mesa.Agent):
     """An agent with fixed initial wealth."""
@@ -36,7 +37,5 @@ if __name__ == "__main__":
 
     agent_wealth = [a.wealth for a in model.agents]
     g = sns.histplot(agent_wealth, discrete=True)
-    g.set(
-        title="Wealth distribution", xlabel="Wealth", ylabel="number of agents"
-    )
+    g.set(title="Wealth distribution", xlabel="Wealth", ylabel="number of agents")
     plt.show()


### PR DESCRIPTION
This PR adds a Boltzmann Wealth Model example with:
- model.py: complete working model
- README.md: explanation and instructions

The model demonstrates how wealth inequality emerges 
from equal starting conditions through random exchanges.