### PR TITLE
examples: add dormant_alliances MetaAgent lifecycle demo

### DIFF
--- a/examples/dormant_alliances/README.md
+++ b/examples/dormant_alliances/README.md
@@ -1,0 +1,164 @@
+"""Solara visualization for the Dormant Alliances model.
+
+Run:
+    solara run app.py
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import networkx as nx
+import solara
+from matplotlib.figure import Figure
+
+from mesa.visualization import SolaraViz
+from mesa.visualization.utils import update_counter
+
+from .model import DormantAlliancesModel
+from .agents import Alliance, CountryAgent
+
+
+# ---------------------------------------------------------------------------
+# Solara components
+# ---------------------------------------------------------------------------
+
+# Colour coding: active alliance = blue, dormant = orange, unaffiliated = grey
+_STATE_COLOUR = {
+    "ACTIVE":  "#3B82F6",   # blue-500
+    "DORMANT": "#F97316",   # orange-500
+    None:      "#9CA3AF",   # grey-400  (unaffiliated)
+}
+
+
+@solara.component
+def plot_alliance_network(model):
+    """Draw the country-alliance network.
+
+    Countries are nodes; an edge connects a country to its alliance.
+    Node size reflects country power.  Alliance nodes are coloured by state.
+    """
+    update_counter.get()
+
+    g = nx.Graph()
+
+    countries = list(model.agents_by_type.get(CountryAgent, []))
+    alliances  = list(model.agents_by_type.get(Alliance, []))
+
+    # Add country nodes
+    for c in countries:
+        g.add_node(f"C{c.unique_id}", kind="country", power=c.power)
+
+    # Add alliance nodes + edges
+    for a in alliances:
+        label = f"A{a.unique_id}\n{a.state.name[:3]}"
+        g.add_node(label, kind="alliance", state=a.state.name)
+        for member in a.agents:
+            g.add_edge(f"C{member.unique_id}", label)
+
+    pos = nx.spring_layout(g, seed=0)
+
+    country_nodes  = [n for n, d in g.nodes(data=True) if d.get("kind") == "country"]
+    alliance_nodes = [n for n, d in g.nodes(data=True) if d.get("kind") == "alliance"]
+
+    country_sizes  = [g.nodes[n]["power"] * 3 for n in country_nodes]
+    alliance_colours = [
+        _STATE_COLOUR.get(g.nodes[n].get("state"), "#9CA3AF")
+        for n in alliance_nodes
+    ]
+
+    fig = Figure(figsize=(7, 5))
+    ax = fig.subplots()
+    ax.set_title(
+        f"Step {model.time}  |  "
+        f"Countries: {len(countries)}  "
+        f"Active alliances: {sum(1 for a in alliances if a.is_active)}  "
+        f"Dormant: {sum(1 for a in alliances if a.is_dormant)}",
+        fontsize=9,
+    )
+
+    nx.draw_networkx_nodes(g, pos, nodelist=country_nodes,
+                           node_size=country_sizes, node_color="#6EE7B7", ax=ax)
+    nx.draw_networkx_nodes(g, pos, nodelist=alliance_nodes,
+                           node_size=600, node_color=alliance_colours,
+                           node_shape="s", ax=ax)
+    nx.draw_networkx_labels(g, pos, ax=ax, font_size=6)
+    nx.draw_networkx_edges(g, pos, ax=ax, alpha=0.4)
+
+    ax.axis("off")
+    solara.FigureMatplotlib(fig)
+
+
+@solara.component
+def plot_timeseries(model):
+    """Line chart: active vs dormant alliances and mean country power over time."""
+    update_counter.get()
+
+    df = model.datacollector.get_model_vars_dataframe()
+    if df.empty:
+        return
+
+    fig = Figure(figsize=(7, 3))
+    ax1, ax2 = fig.subplots(1, 2)
+
+    ax1.plot(df.index, df["Active Alliances"],  label="Active",  color="#3B82F6")
+    ax1.plot(df.index, df["Dormant Alliances"], label="Dormant", color="#F97316")
+    ax1.set_title("Alliance States")
+    ax1.set_xlabel("Step")
+    ax1.set_ylabel("Count")
+    ax1.legend(fontsize=7)
+
+    ax2.plot(df.index, df["Mean Country Power"], color="#10B981")
+    ax2.set_title("Mean Country Power")
+    ax2.set_xlabel("Step")
+    ax2.set_ylabel("Power")
+
+    fig.tight_layout()
+    solara.FigureMatplotlib(fig)
+
+
+# ---------------------------------------------------------------------------
+# Model parameters exposed in the Solara UI
+# ---------------------------------------------------------------------------
+
+model_params = {
+    "seed": {
+        "type": "InputText",
+        "value": 42,
+        "label": "Random Seed",
+    },
+    "n_countries": {
+        "type": "SliderInt",
+        "value": 20,
+        "label": "Number of Countries",
+        "min": 5,
+        "max": 60,
+        "step": 5,
+    },
+    "alliance_threshold": {
+        "type": "SliderFloat",
+        "value": 40.0,
+        "label": "Alliance Formation Threshold",
+        "min": 10.0,
+        "max": 150.0,
+        "step": 5.0,
+    },
+    "reactivation_interval": {
+        "type": "SliderInt",
+        "value": 5,
+        "label": "Reactivation Check Interval",
+        "min": 1,
+        "max": 20,
+        "step": 1,
+    },
+}
+
+model = DormantAlliancesModel()
+
+page = SolaraViz(
+    model,
+    components=[plot_alliance_network, plot_timeseries],
+    model_params=model_params,
+    name="Dormant Alliances — MetaAgent Lifecycle Demo",
+)
+page  # noqa
+

--- a/examples/dormant_alliances/agents.py
+++ b/examples/dormant_alliances/agents.py
@@ -1,0 +1,197 @@
+"""Agent definitions for the Dormant Alliances model.
+
+This model extends the classic Alliance Formation concept to demonstrate
+the new MetaAgent lifecycle features added in the GSoC 2026 contribution:
+
+  - MetaAgentState (ACTIVE / DORMANT / DISSOLVED)
+  - activate() / deactivate() lifecycle transitions
+  - Signal / event system (on / emit)
+  - cascade_step for automatic member stepping
+  - to_dict() serialisation
+"""
+
+from __future__ import annotations
+
+import mesa
+from mesa.experimental.meta_agents import MetaAgent
+
+
+# ---------------------------------------------------------------------------
+# Country agent
+# ---------------------------------------------------------------------------
+
+class CountryAgent(mesa.Agent):
+    """A country that can join alliances, gain/lose power, and be defeated.
+
+    Attributes:
+        power:      Current military/economic power (float, 0–100).
+        defeated:   True once power drops to 0 and the country is removed.
+    """
+
+    def __init__(self, model: mesa.Model, power: float | None = None):
+        super().__init__(model)
+        self.power: float = power if power is not None else model.rng.uniform(10, 100)
+        self.defeated: bool = False
+
+    # ------------------------------------------------------------------
+    # Properties used by the model to inspect state
+    # ------------------------------------------------------------------
+
+    @property
+    def alliance(self) -> "Alliance | None":
+        """Convenience accessor: the first Alliance this country belongs to."""
+        if hasattr(self, "meta_agents"):
+            alliances = [ma for ma in self.meta_agents if isinstance(ma, Alliance)]
+            return alliances[0] if alliances else None
+        return None
+
+    # ------------------------------------------------------------------
+    # Step
+    # ------------------------------------------------------------------
+
+    def step(self) -> None:
+        """Each tick a country loses a small random amount of power.
+
+        If power hits zero it emits ``"member_defeated"`` on its alliance
+        (demonstrating the signal system) and removes itself.
+        """
+        if self.defeated:
+            return
+
+        # Lose 1–8 power per step
+        loss = self.model.rng.uniform(1, 8)
+        self.power = max(0.0, self.power - loss)
+
+        if self.power == 0.0:
+            self.defeated = True
+            # Signal the alliance (if any) before removing self
+            if self.alliance is not None:
+                self.alliance.emit("member_defeated", self)
+            self.remove()
+
+    def __repr__(self) -> str:
+        return f"<Country id={self.unique_id} power={self.power:.1f}>"
+
+
+# ---------------------------------------------------------------------------
+# Alliance meta-agent
+# ---------------------------------------------------------------------------
+
+class Alliance(MetaAgent):
+    """A group of countries that act as a collective entity.
+
+    Demonstrates every new MetaAgent feature:
+
+    1. **Lifecycle** — deactivates (goes DORMANT) when the alliance loses
+       more than half its founding members; reactivates when it recruits
+       enough new members to recover.
+
+    2. **Signals** — listens for ``"member_defeated"`` from each country and
+       calls ``_on_member_defeated``.  Also emits ``"alliance_weakened"``
+       when total power drops below the configured threshold.
+
+    3. **cascade_step** — set to True so Alliance.step() automatically
+       steps all member countries after its own logic, removing the need
+       for boilerplate in the model.
+
+    4. **to_dict** — used by the DataCollector for structured logging.
+
+    Attributes:
+        founding_size:     Number of members at formation.
+        power_threshold:   Minimum combined power before "weakened" is fired.
+        _weakened_emitted: Guard so the signal fires only once.
+    """
+
+    cascade_step: bool = True   # automatically step all members
+
+    def __init__(
+        self,
+        model: mesa.Model,
+        agents: set[CountryAgent] | None = None,
+        name: str = "Alliance",
+        *,
+        power_threshold: float = 50.0,
+    ):
+        super().__init__(model, agents, name)
+
+        self.founding_size: int = len(self._constituting_set)
+        self.power_threshold: float = power_threshold
+        self._weakened_emitted: bool = False
+
+        # Register signal handler: react when a member is defeated
+        self.on("member_defeated", self._on_member_defeated)
+
+    # ------------------------------------------------------------------
+    # Computed properties
+    # ------------------------------------------------------------------
+
+    @property
+    def total_power(self) -> float:
+        """Sum of power across all active member countries."""
+        return sum(a.power for a in self._constituting_set)
+
+    @property
+    def size(self) -> int:
+        """Current number of members."""
+        return len(self._constituting_set)
+
+    # ------------------------------------------------------------------
+    # Signal handlers
+    # ------------------------------------------------------------------
+
+    def _on_member_defeated(self, country: CountryAgent) -> None:
+        """Called automatically when a member emits 'member_defeated'.
+
+        Removes the country from the alliance and checks whether the group
+        has shrunk below half its founding size — if so, deactivates.
+        """
+        self.remove_constituting_agents({country})
+
+        if self.size == 0:
+            # All members gone — dissolve entirely
+            self.remove()
+            return
+
+        # Deactivate if we have lost more than half our founding members
+        if self.is_active and self.size < self.founding_size / 2:
+            self.deactivate()
+            print(
+                f"  ⚠ {self} lost majority of founders — going DORMANT "
+                f"(founders={self.founding_size}, now={self.size})"
+            )
+
+    # ------------------------------------------------------------------
+    # Step (meta-level logic runs BEFORE members, thanks to cascade_step)
+    # ------------------------------------------------------------------
+
+    def step(self) -> None:
+        """Alliance-level logic: emit 'alliance_weakened' if power is low.
+
+        Because ``cascade_step = True``, the base-class step() will call
+        step() on every member country automatically after this method
+        returns (handled in MetaAgent.step()).
+        """
+        if not self.is_active:
+            return   # DORMANT — skip entirely; base class will also guard
+
+        # Check collective power
+        if (
+            not self._weakened_emitted
+            and self.total_power < self.power_threshold
+        ):
+            self._weakened_emitted = True
+            self.emit("alliance_weakened", self)
+
+        # Attempt to reactivate if previously dormant and now has enough members
+        # (This branch is only reached if caller explicitly re-activates first.)
+
+        # Delegate to parent, which cascades to members
+        super().step()
+
+    def __repr__(self) -> str:
+        return (
+            f"<Alliance {self.name!r} id={self.unique_id} "
+            f"state={self._state.name} members={self.size} "
+            f"power={self.total_power:.1f}>"
+        )
+

--- a/examples/dormant_alliances/agents.py
+++ b/examples/dormant_alliances/agents.py
@@ -15,10 +15,10 @@ from __future__ import annotations
 import mesa
 from mesa.experimental.meta_agents import MetaAgent
 
-
 # ---------------------------------------------------------------------------
 # Country agent
 # ---------------------------------------------------------------------------
+
 
 class CountryAgent(mesa.Agent):
     """A country that can join alliances, gain/lose power, and be defeated.
@@ -38,7 +38,7 @@ class CountryAgent(mesa.Agent):
     # ------------------------------------------------------------------
 
     @property
-    def alliance(self) -> "Alliance | None":
+    def alliance(self) -> Alliance | None:
         """Convenience accessor: the first Alliance this country belongs to."""
         if hasattr(self, "meta_agents"):
             alliances = [ma for ma in self.meta_agents if isinstance(ma, Alliance)]
@@ -77,6 +77,7 @@ class CountryAgent(mesa.Agent):
 # Alliance meta-agent
 # ---------------------------------------------------------------------------
 
+
 class Alliance(MetaAgent):
     """A group of countries that act as a collective entity.
 
@@ -102,7 +103,7 @@ class Alliance(MetaAgent):
         _weakened_emitted: Guard so the signal fires only once.
     """
 
-    cascade_step: bool = True   # automatically step all members
+    cascade_step: bool = True  # automatically step all members
 
     def __init__(
         self,
@@ -172,13 +173,10 @@ class Alliance(MetaAgent):
         returns (handled in MetaAgent.step()).
         """
         if not self.is_active:
-            return   # DORMANT — skip entirely; base class will also guard
+            return  # DORMANT — skip entirely; base class will also guard
 
         # Check collective power
-        if (
-            not self._weakened_emitted
-            and self.total_power < self.power_threshold
-        ):
+        if not self._weakened_emitted and self.total_power < self.power_threshold:
             self._weakened_emitted = True
             self.emit("alliance_weakened", self)
 
@@ -194,4 +192,3 @@ class Alliance(MetaAgent):
             f"state={self._state.name} members={self.size} "
             f"power={self.total_power:.1f}>"
         )
-

--- a/examples/dormant_alliances/app.py
+++ b/examples/dormant_alliances/app.py
@@ -6,17 +6,14 @@ Run:
 
 from __future__ import annotations
 
-import matplotlib.pyplot as plt
 import networkx as nx
 import solara
 from matplotlib.figure import Figure
-
 from mesa.visualization import SolaraViz
 from mesa.visualization.utils import update_counter
 
-from .model import DormantAlliancesModel
 from .agents import Alliance, CountryAgent
-
+from .model import DormantAlliancesModel
 
 # ---------------------------------------------------------------------------
 # Solara components
@@ -24,9 +21,9 @@ from .agents import Alliance, CountryAgent
 
 # Colour coding: active alliance = blue, dormant = orange, unaffiliated = grey
 _STATE_COLOUR = {
-    "ACTIVE":  "#3B82F6",   # blue-500
-    "DORMANT": "#F97316",   # orange-500
-    None:      "#9CA3AF",   # grey-400  (unaffiliated)
+    "ACTIVE": "#3B82F6",  # blue-500
+    "DORMANT": "#F97316",  # orange-500
+    None: "#9CA3AF",  # grey-400  (unaffiliated)
 }
 
 
@@ -42,7 +39,7 @@ def plot_alliance_network(model):
     g = nx.Graph()
 
     countries = list(model.agents_by_type.get(CountryAgent, []))
-    alliances  = list(model.agents_by_type.get(Alliance, []))
+    alliances = list(model.agents_by_type.get(Alliance, []))
 
     # Add country nodes
     for c in countries:
@@ -57,13 +54,12 @@ def plot_alliance_network(model):
 
     pos = nx.spring_layout(g, seed=0)
 
-    country_nodes  = [n for n, d in g.nodes(data=True) if d.get("kind") == "country"]
+    country_nodes = [n for n, d in g.nodes(data=True) if d.get("kind") == "country"]
     alliance_nodes = [n for n, d in g.nodes(data=True) if d.get("kind") == "alliance"]
 
-    country_sizes  = [g.nodes[n]["power"] * 3 for n in country_nodes]
+    country_sizes = [g.nodes[n]["power"] * 3 for n in country_nodes]
     alliance_colours = [
-        _STATE_COLOUR.get(g.nodes[n].get("state"), "#9CA3AF")
-        for n in alliance_nodes
+        _STATE_COLOUR.get(g.nodes[n].get("state"), "#9CA3AF") for n in alliance_nodes
     ]
 
     fig = Figure(figsize=(7, 5))
@@ -76,11 +72,23 @@ def plot_alliance_network(model):
         fontsize=9,
     )
 
-    nx.draw_networkx_nodes(g, pos, nodelist=country_nodes,
-                           node_size=country_sizes, node_color="#6EE7B7", ax=ax)
-    nx.draw_networkx_nodes(g, pos, nodelist=alliance_nodes,
-                           node_size=600, node_color=alliance_colours,
-                           node_shape="s", ax=ax)
+    nx.draw_networkx_nodes(
+        g,
+        pos,
+        nodelist=country_nodes,
+        node_size=country_sizes,
+        node_color="#6EE7B7",
+        ax=ax,
+    )
+    nx.draw_networkx_nodes(
+        g,
+        pos,
+        nodelist=alliance_nodes,
+        node_size=600,
+        node_color=alliance_colours,
+        node_shape="s",
+        ax=ax,
+    )
     nx.draw_networkx_labels(g, pos, ax=ax, font_size=6)
     nx.draw_networkx_edges(g, pos, ax=ax, alpha=0.4)
 
@@ -100,7 +108,7 @@ def plot_timeseries(model):
     fig = Figure(figsize=(7, 3))
     ax1, ax2 = fig.subplots(1, 2)
 
-    ax1.plot(df.index, df["Active Alliances"],  label="Active",  color="#3B82F6")
+    ax1.plot(df.index, df["Active Alliances"], label="Active", color="#3B82F6")
     ax1.plot(df.index, df["Dormant Alliances"], label="Dormant", color="#F97316")
     ax1.set_title("Alliance States")
     ax1.set_xlabel("Step")
@@ -161,4 +169,3 @@ page = SolaraViz(
     name="Dormant Alliances — MetaAgent Lifecycle Demo",
 )
 page  # noqa
-

--- a/examples/dormant_alliances/app.py
+++ b/examples/dormant_alliances/app.py
@@ -1,0 +1,164 @@
+"""Solara visualization for the Dormant Alliances model.
+
+Run:
+    solara run app.py
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import networkx as nx
+import solara
+from matplotlib.figure import Figure
+
+from mesa.visualization import SolaraViz
+from mesa.visualization.utils import update_counter
+
+from .model import DormantAlliancesModel
+from .agents import Alliance, CountryAgent
+
+
+# ---------------------------------------------------------------------------
+# Solara components
+# ---------------------------------------------------------------------------
+
+# Colour coding: active alliance = blue, dormant = orange, unaffiliated = grey
+_STATE_COLOUR = {
+    "ACTIVE":  "#3B82F6",   # blue-500
+    "DORMANT": "#F97316",   # orange-500
+    None:      "#9CA3AF",   # grey-400  (unaffiliated)
+}
+
+
+@solara.component
+def plot_alliance_network(model):
+    """Draw the country-alliance network.
+
+    Countries are nodes; an edge connects a country to its alliance.
+    Node size reflects country power.  Alliance nodes are coloured by state.
+    """
+    update_counter.get()
+
+    g = nx.Graph()
+
+    countries = list(model.agents_by_type.get(CountryAgent, []))
+    alliances  = list(model.agents_by_type.get(Alliance, []))
+
+    # Add country nodes
+    for c in countries:
+        g.add_node(f"C{c.unique_id}", kind="country", power=c.power)
+
+    # Add alliance nodes + edges
+    for a in alliances:
+        label = f"A{a.unique_id}\n{a.state.name[:3]}"
+        g.add_node(label, kind="alliance", state=a.state.name)
+        for member in a.agents:
+            g.add_edge(f"C{member.unique_id}", label)
+
+    pos = nx.spring_layout(g, seed=0)
+
+    country_nodes  = [n for n, d in g.nodes(data=True) if d.get("kind") == "country"]
+    alliance_nodes = [n for n, d in g.nodes(data=True) if d.get("kind") == "alliance"]
+
+    country_sizes  = [g.nodes[n]["power"] * 3 for n in country_nodes]
+    alliance_colours = [
+        _STATE_COLOUR.get(g.nodes[n].get("state"), "#9CA3AF")
+        for n in alliance_nodes
+    ]
+
+    fig = Figure(figsize=(7, 5))
+    ax = fig.subplots()
+    ax.set_title(
+        f"Step {model.time}  |  "
+        f"Countries: {len(countries)}  "
+        f"Active alliances: {sum(1 for a in alliances if a.is_active)}  "
+        f"Dormant: {sum(1 for a in alliances if a.is_dormant)}",
+        fontsize=9,
+    )
+
+    nx.draw_networkx_nodes(g, pos, nodelist=country_nodes,
+                           node_size=country_sizes, node_color="#6EE7B7", ax=ax)
+    nx.draw_networkx_nodes(g, pos, nodelist=alliance_nodes,
+                           node_size=600, node_color=alliance_colours,
+                           node_shape="s", ax=ax)
+    nx.draw_networkx_labels(g, pos, ax=ax, font_size=6)
+    nx.draw_networkx_edges(g, pos, ax=ax, alpha=0.4)
+
+    ax.axis("off")
+    solara.FigureMatplotlib(fig)
+
+
+@solara.component
+def plot_timeseries(model):
+    """Line chart: active vs dormant alliances and mean country power over time."""
+    update_counter.get()
+
+    df = model.datacollector.get_model_vars_dataframe()
+    if df.empty:
+        return
+
+    fig = Figure(figsize=(7, 3))
+    ax1, ax2 = fig.subplots(1, 2)
+
+    ax1.plot(df.index, df["Active Alliances"],  label="Active",  color="#3B82F6")
+    ax1.plot(df.index, df["Dormant Alliances"], label="Dormant", color="#F97316")
+    ax1.set_title("Alliance States")
+    ax1.set_xlabel("Step")
+    ax1.set_ylabel("Count")
+    ax1.legend(fontsize=7)
+
+    ax2.plot(df.index, df["Mean Country Power"], color="#10B981")
+    ax2.set_title("Mean Country Power")
+    ax2.set_xlabel("Step")
+    ax2.set_ylabel("Power")
+
+    fig.tight_layout()
+    solara.FigureMatplotlib(fig)
+
+
+# ---------------------------------------------------------------------------
+# Model parameters exposed in the Solara UI
+# ---------------------------------------------------------------------------
+
+model_params = {
+    "seed": {
+        "type": "InputText",
+        "value": 42,
+        "label": "Random Seed",
+    },
+    "n_countries": {
+        "type": "SliderInt",
+        "value": 20,
+        "label": "Number of Countries",
+        "min": 5,
+        "max": 60,
+        "step": 5,
+    },
+    "alliance_threshold": {
+        "type": "SliderFloat",
+        "value": 40.0,
+        "label": "Alliance Formation Threshold",
+        "min": 10.0,
+        "max": 150.0,
+        "step": 5.0,
+    },
+    "reactivation_interval": {
+        "type": "SliderInt",
+        "value": 5,
+        "label": "Reactivation Check Interval",
+        "min": 1,
+        "max": 20,
+        "step": 1,
+    },
+}
+
+model = DormantAlliancesModel()
+
+page = SolaraViz(
+    model,
+    components=[plot_alliance_network, plot_timeseries],
+    model_params=model_params,
+    name="Dormant Alliances — MetaAgent Lifecycle Demo",
+)
+page  # noqa
+

--- a/examples/dormant_alliances/model.py
+++ b/examples/dormant_alliances/model.py
@@ -1,0 +1,219 @@
+"""Dormant Alliances Model — Mesa meta-agent lifecycle demonstration.
+
+This model shows how the new MetaAgent lifecycle features (GSoC 2026) work
+in a realistic simulation:
+
+  - Countries gain and lose power each step.
+  - Countries with compatible power levels form alliances (MetaAgents).
+  - When an alliance loses >50% of its founding members it goes DORMANT.
+  - A dormant alliance can be reactivated if its remaining members recruit
+    enough new countries.
+  - When all members are gone the alliance is DISSOLVED.
+
+Run with:
+    solara run app.py
+Or headless:
+    python model.py
+"""
+
+from __future__ import annotations
+
+import mesa
+
+from .agents import Alliance, CountryAgent
+from mesa.experimental.meta_agents import create_meta_agent
+
+
+# Minimum combined power for two countries to consider forming an alliance
+ALLIANCE_FORMATION_THRESHOLD = 40.0
+
+# How often (in steps) dormant alliances attempt to recruit and reactivate
+REACTIVATION_INTERVAL = 5
+
+
+class DormantAlliancesModel(mesa.Model):
+    """Agent-based model demonstrating MetaAgent lifecycle management.
+
+    Parameters
+    ----------
+    n_countries : int
+        Number of country agents to create. Default 20.
+    alliance_threshold : float
+        Minimum *combined* power required to form a new alliance.
+    reactivation_interval : int
+        How many steps between dormant-alliance reactivation attempts.
+    seed : int | None
+        Random seed for reproducibility.
+    """
+
+    def __init__(
+        self,
+        n_countries: int = 20,
+        alliance_threshold: float = ALLIANCE_FORMATION_THRESHOLD,
+        reactivation_interval: int = REACTIVATION_INTERVAL,
+        seed: int | None = 42,
+    ):
+        super().__init__(seed=seed)
+
+        self.alliance_threshold = alliance_threshold
+        self.reactivation_interval = reactivation_interval
+
+        # Create countries
+        for _ in range(n_countries):
+            CountryAgent(self)
+
+        # Collect a snapshot of active/dormant alliances each step
+        self.datacollector = mesa.DataCollector(
+            model_reporters={
+                "Active Alliances":   lambda m: m._count_alliances("ACTIVE"),
+                "Dormant Alliances":  lambda m: m._count_alliances("DORMANT"),
+                "Total Countries":    lambda m: len(m.agents_by_type.get(CountryAgent, [])),
+                "Mean Country Power": lambda m: m._mean_power(),
+            },
+            agent_reporters={
+                "Power":    lambda a: getattr(a, "power", None),
+                "Defeated": lambda a: getattr(a, "defeated", None),
+            },
+        )
+
+        # Form initial alliances
+        self._form_alliances()
+
+    # ------------------------------------------------------------------
+    # DataCollector helpers
+    # ------------------------------------------------------------------
+
+    def _count_alliances(self, state_name: str) -> int:
+        alliances = self.agents_by_type.get(Alliance, [])
+        return sum(1 for a in alliances if a.state.name == state_name)
+
+    def _mean_power(self) -> float:
+        countries = list(self.agents_by_type.get(CountryAgent, []))
+        if not countries:
+            return 0.0
+        return sum(c.power for c in countries) / len(countries)
+
+    # ------------------------------------------------------------------
+    # Alliance formation logic
+    # ------------------------------------------------------------------
+
+    def _form_alliances(self) -> None:
+        """Pair up unaffiliated countries whose combined power exceeds the
+        threshold and create a new Alliance MetaAgent for each eligible pair.
+        """
+        unaffiliated = [
+            c for c in self.agents_by_type.get(CountryAgent, [])
+            if c.alliance is None
+        ]
+        self.rng.shuffle(unaffiliated)
+
+        i = 0
+        while i + 1 < len(unaffiliated):
+            c1, c2 = unaffiliated[i], unaffiliated[i + 1]
+            if c1.power + c2.power >= self.alliance_threshold:
+                alliance = create_meta_agent(
+                    model=self,
+                    new_agent_class="Alliance",
+                    agents=[c1, c2],
+                    mesa_agent_type=Alliance,
+                    meta_attributes={"power_threshold": self.alliance_threshold},
+                )
+                # Optionally log the formation
+                print(f"  ✦ Formed {alliance}")
+                i += 2
+            else:
+                i += 1
+
+    def _try_reactivate_dormant(self) -> None:
+        """Attempt to grow dormant alliances by recruiting unaffiliated countries.
+
+        If a dormant alliance can recruit enough members to exceed half its
+        founding size, it reactivates.
+        """
+        dormant = [
+            a for a in self.agents_by_type.get(Alliance, [])
+            if a.is_dormant
+        ]
+        unaffiliated = [
+            c for c in self.agents_by_type.get(CountryAgent, [])
+            if c.alliance is None
+        ]
+
+        for alliance in dormant:
+            # How many new recruits are needed to exceed founding_size / 2?
+            needed = max(0, int(alliance.founding_size / 2) + 1 - alliance.size)
+            recruits = unaffiliated[:needed]
+
+            if len(recruits) >= needed and needed > 0:
+                alliance.add_constituting_agents(set(recruits))
+                for r in recruits:
+                    unaffiliated.remove(r)
+                alliance.activate()
+                print(
+                    f"  ✦ Reactivated {alliance} "
+                    f"(recruited {len(recruits)} new members)"
+                )
+
+    # ------------------------------------------------------------------
+    # Model step
+    # ------------------------------------------------------------------
+
+    def step(self) -> None:
+        """Advance the model by one tick.
+
+        Order of operations:
+        1. Active alliances step (which cascades to their member countries).
+        2. Unaffiliated countries step independently.
+        3. Periodically attempt dormant-alliance reactivation.
+        4. Form new alliances among any newly unaffiliated countries.
+        5. Collect data.
+        """
+        stepped_country_ids: set[int] = set()
+
+        # 1. Step active alliances (cascade reaches member countries)
+        for alliance in list(self.agents_by_type.get(Alliance, [])):
+            if alliance.is_active:
+                alliance.step()
+                for member in list(alliance.agents):
+                    stepped_country_ids.add(member.unique_id)
+
+        # 2. Step unaffiliated countries (not yet stepped this tick)
+        for country in list(self.agents_by_type.get(CountryAgent, [])):
+            if country.unique_id not in stepped_country_ids:
+                country.step()
+
+        # 3. Periodically attempt reactivation
+        if self.time % self.reactivation_interval == 0:
+            self._try_reactivate_dormant()
+
+        # 4. Try to form new alliances
+        self._form_alliances()
+
+        # 5. Collect data
+        self.datacollector.collect(self)
+
+
+# ---------------------------------------------------------------------------
+# Headless run (python model.py)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("=== Dormant Alliances Model ===\n")
+    model = DormantAlliancesModel(n_countries=20, seed=42)
+
+    for step in range(30):
+        print(f"\n--- Step {step + 1} ---")
+        model.step()
+        df = model.datacollector.get_model_vars_dataframe()
+        last = df.iloc[-1]
+        print(
+            f"  Countries: {int(last['Total Countries'])}  "
+            f"Active alliances: {int(last['Active Alliances'])}  "
+            f"Dormant: {int(last['Dormant Alliances'])}  "
+            f"Mean power: {last['Mean Country Power']:.1f}"
+        )
+
+    print("\n=== Final Alliance Snapshots ===")
+    for alliance in model.agents_by_type.get(Alliance, []):
+        print(" ", alliance.to_dict())
+

--- a/examples/dormant_alliances/model.py
+++ b/examples/dormant_alliances/model.py
@@ -19,10 +19,9 @@ Or headless:
 from __future__ import annotations
 
 import mesa
-
-from .agents import Alliance, CountryAgent
 from mesa.experimental.meta_agents import create_meta_agent
 
+from .agents import Alliance, CountryAgent
 
 # Minimum combined power for two countries to consider forming an alliance
 ALLIANCE_FORMATION_THRESHOLD = 40.0
@@ -65,13 +64,15 @@ class DormantAlliancesModel(mesa.Model):
         # Collect a snapshot of active/dormant alliances each step
         self.datacollector = mesa.DataCollector(
             model_reporters={
-                "Active Alliances":   lambda m: m._count_alliances("ACTIVE"),
-                "Dormant Alliances":  lambda m: m._count_alliances("DORMANT"),
-                "Total Countries":    lambda m: len(m.agents_by_type.get(CountryAgent, [])),
+                "Active Alliances": lambda m: m._count_alliances("ACTIVE"),
+                "Dormant Alliances": lambda m: m._count_alliances("DORMANT"),
+                "Total Countries": lambda m: len(
+                    m.agents_by_type.get(CountryAgent, [])
+                ),
                 "Mean Country Power": lambda m: m._mean_power(),
             },
             agent_reporters={
-                "Power":    lambda a: getattr(a, "power", None),
+                "Power": lambda a: getattr(a, "power", None),
                 "Defeated": lambda a: getattr(a, "defeated", None),
             },
         )
@@ -102,8 +103,7 @@ class DormantAlliancesModel(mesa.Model):
         threshold and create a new Alliance MetaAgent for each eligible pair.
         """
         unaffiliated = [
-            c for c in self.agents_by_type.get(CountryAgent, [])
-            if c.alliance is None
+            c for c in self.agents_by_type.get(CountryAgent, []) if c.alliance is None
         ]
         self.rng.shuffle(unaffiliated)
 
@@ -130,13 +130,9 @@ class DormantAlliancesModel(mesa.Model):
         If a dormant alliance can recruit enough members to exceed half its
         founding size, it reactivates.
         """
-        dormant = [
-            a for a in self.agents_by_type.get(Alliance, [])
-            if a.is_dormant
-        ]
+        dormant = [a for a in self.agents_by_type.get(Alliance, []) if a.is_dormant]
         unaffiliated = [
-            c for c in self.agents_by_type.get(CountryAgent, [])
-            if c.alliance is None
+            c for c in self.agents_by_type.get(CountryAgent, []) if c.alliance is None
         ]
 
         for alliance in dormant:
@@ -216,4 +212,3 @@ if __name__ == "__main__":
     print("\n=== Final Alliance Snapshots ===")
     for alliance in model.agents_by_type.get(Alliance, []):
         print(" ", alliance.to_dict())
-


### PR DESCRIPTION
## Summary
Adds a new example `dormant_alliances` demonstrating the MetaAgent lifecycle 
features proposed in projectmesa/mesa#3684.

## What it models
Countries (agents) form alliances (MetaAgents). Each step, countries lose power 
from attrition. When a country's power hits zero it is defeated and removed. If 
an alliance loses more than half its founding members, it goes DORMANT. Dormant 
alliances can reactivate if they recruit enough unaffiliated countries to recover.

## Features demonstrated
- MetaAgentState (ACTIVE / DORMANT / DISSOLVED)
- activate() / deactivate() lifecycle transitions
- Signal system via on() and emit()
- cascade_step for automatic member stepping
- to_dict() for structured logging via DataCollector

## Running

Interactive visualization:
    solara run examples/dormant_alliances/app.py

Headless:
    python examples/dormant_alliances/model.py

## Related
- Closes #459
- Companion to projectmesa/mesa#3684