### PR TITLE
fix(bank-reserves): migrate to SpaceRenderer and AgentPortrayalStyle

### DIFF
--- a/examples/bank_reserves/Readme.md
+++ b/examples/bank_reserves/Readme.md
@@ -5,12 +5,12 @@
 A highly abstracted, simplified model of an economy, with only one type of agent and a single bank representing all banks in an economy. People (represented by circles) move randomly within the grid. If two or more people are on the same grid location, there is a 50% chance that they will trade with each other. If they trade, there is an equal chance of giving the other agent $5 or $2. A positive trade balance will be deposited in the bank as savings. If trading results in a negative balance, the agent will try to withdraw from its savings to cover the balance. If it does not have enough savings to cover the negative balance, it will take out a loan from the bank to cover the difference. The bank is required to keep a certain percentage of deposits as reserves. If run.py is used to run the model, then the percent of deposits the bank is required to retain is a user settable parameter. The amount the bank is able to loan at any given time is a function of the amount of deposits, its reserves, and its current total outstanding loan amount.
 
 The model demonstrates the following Mesa features:
- - MultiGrid for creating shareable space for agents
- - DataCollector for collecting data on individual model runs
- - Slider for adjusting initial model parameters
- - ModularServer for visualization of agent interaction
+ - `OrthogonalMooreGrid` for creating shareable space for agents
+ - `DataCollector` for collecting data on individual model runs
+ - `Slider` for adjusting initial model parameters
+ - `SolaraViz` with `SpaceRenderer` for visualization of agent interaction
  - Agent object inheritance
- - Using a BatchRunner to collect data on multiple combinations of model parameters
+ - Using `batch_run` to collect data on multiple combinations of model parameters
 
 ## Installation
 

--- a/examples/bank_reserves/app.py
+++ b/examples/bank_reserves/app.py
@@ -1,13 +1,8 @@
 from bank_reserves.agents import Person
 from bank_reserves.model import BankReservesModel
-from mesa.visualization import (
-    SolaraViz,
-    make_plot_component,
-    make_space_component,
-)
-from mesa.visualization.user_param import (
-    Slider,
-)
+from mesa.visualization import SolaraViz, SpaceRenderer, make_plot_component
+from mesa.visualization.components.portrayal_components import AgentPortrayalStyle
+from mesa.visualization.user_param import Slider
 
 # The colors here are taken from Matplotlib's tab10 palette
 # Green
@@ -22,28 +17,18 @@ def person_portrayal(agent):
     if agent is None:
         return
 
-    portrayal = {}
+    if not isinstance(agent, Person):
+        return
 
-    # update portrayal characteristics for each Person object
-    if isinstance(agent, Person):
-        portrayal["Shape"] = "circle"
-        portrayal["r"] = 0.5
-        portrayal["Layer"] = 0
-        portrayal["Filled"] = "true"
-
+    # set agent color based on savings and loans
+    if agent.savings > agent.model.rich_threshold:
+        color = RICH_COLOR
+    elif agent.loans > 10:
+        color = POOR_COLOR
+    else:
         color = MID_COLOR
 
-        # set agent color based on savings and loans
-        if agent.savings > agent.model.rich_threshold:
-            color = RICH_COLOR
-        if agent.savings < 10 and agent.loans < 10:
-            color = MID_COLOR
-        if agent.loans > 10:
-            color = POOR_COLOR
-
-        portrayal["color"] = color
-
-    return portrayal
+    return AgentPortrayalStyle(color=color, size=50, marker="o")
 
 
 def post_process_space(ax):
@@ -81,20 +66,21 @@ model_params = {
     ),
 }
 
-space_component = make_space_component(
-    person_portrayal,
-    draw_grid=False,
-    post_process=post_process_space,
-)
+model = BankReservesModel()
+
+renderer = SpaceRenderer(model, backend="matplotlib").setup_agents(person_portrayal)
+renderer.post_process = post_process_space
+renderer.draw_agents()
+
 lineplot_component = make_plot_component(
     {"Rich": RICH_COLOR, "Poor": POOR_COLOR, "Middle Class": MID_COLOR},
     post_process=post_process_lines,
 )
-model = BankReservesModel()
 
 page = SolaraViz(
     model,
-    components=[space_component, lineplot_component],
+    renderer,
+    components=[lineplot_component],
     model_params=model_params,
     name="Bank Reserves Model",
 )


### PR DESCRIPTION
## Summary

- Replaces the deprecated dict-based `agent_portrayal` with `AgentPortrayalStyle` (fixes the deprecation warning reported in #318)
- Migrates from the old `make_space_component` API to the new `SpaceRenderer.setup_agents()` pattern, consistent with other updated examples in the repo
- Simplifies the color-classification logic in `person_portrayal` (removed a redundant branch that reset to `MID_COLOR`)
- Updates `Readme.md` to remove references to removed Mesa APIs (`MultiGrid`, `ModularServer`, `BatchRunner`) and replace with current equivalents (`OrthogonalMooreGrid`, `SolaraViz`/`SpaceRenderer`, `batch_run`)

Closes #318

## Test plan

- [ ] `solara run app.py` runs without deprecation warnings
- [ ] Agents render correctly (rich = green, poor = red, middle = blue)
- [ ] Sliders update the model parameters correctly
- [ ] Line plot shows Rich/Poor/Middle Class trends over time
- [ ] `python batch_run.py` completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)